### PR TITLE
release: 3.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-05-29
+
+A security and correctness patch. No API changes; no migration needed.
+
+### Security
+- **User-defined MCP sources are validated on load.** Entries in
+  `~/.config/docpull-mcp/sources.yaml` are now rejected unless the name is a
+  safe identifier, the URL is HTTPS to a public host (private, loopback,
+  link-local, and internal-suffix hosts are blocked), and `max_pages` is in
+  range. Previously a hand-edited config could point `ensure_docs` at an
+  internal address.
+- **`grep_docs` bounds regex execution per line.** On top of the existing
+  total wall-clock budget, each line now matches under a per-line timeout,
+  closing the remaining catastrophic-backtracking (ReDoS) window for a
+  pathological pattern against a single long line.
+
+### Fixed
+- **Cache timestamps are timezone-aware UTC.** Persisted timestamps (cache
+  manifest, save steps, MCP metadata) use UTC consistently; legacy naive
+  timestamps are parsed as UTC so cache-TTL comparisons stay deterministic
+  instead of mis-expiring entries.
+- **Swallowed exceptions are now logged.** robots.txt parsing, the OpenAPI
+  and SPA heuristics, and link extraction log skipped or invalid input at
+  debug level instead of silently dropping it.
+
 ## [3.0.0] - 2026-04-26
 
 The deprecations 2.4 promised. Six config fields that have emitted a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "3.0.0"
+version = "3.0.1"
 dynamic = []
 description = "Pull documentation from the web and convert to clean markdown"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
Patch release. Bumps version to **3.0.1** and adds the changelog for the security + correctness fixes already merged to `main` since `v3.0.0`:

- MCP user-source SSRF validation + `grep_docs` per-line ReDoS timeout
- UTC-aware cache timestamps (correctness fix — naive timestamps could mis-expire the cache)
- logged (no longer silently swallowed) exceptions in robots / OpenAPI+SPA heuristics / link extraction

No API changes, no breaking changes. After merge, pushing the `v3.0.1` tag triggers `publish.yml` (release gates → OIDC publish to PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)