### PR TITLE
release: 3.0.2 MCP stdio verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,28 @@ pip install 'docpull[mcp]'
 docpull mcp  # starts the stdio server
 ```
 
-Add to Claude Desktop or Claude Code manually:
+Claude Code:
+
+```bash
+claude mcp add --transport stdio docpull -- docpull mcp
+```
+
+Cursor (`.cursor/mcp.json` in a project, or `~/.cursor/mcp.json` globally):
 
 ```json
 {
   "mcpServers": {
     "docpull": {
+      "type": "stdio",
       "command": "docpull",
       "args": ["mcp"]
     }
   }
 }
 ```
+
+Claude Desktop uses the same `mcpServers` shape in
+`claude_desktop_config.json`.
 
 Or, if you use Claude Code, install the plugin instead — it bundles the MCP
 server, five slash commands (`/docs-add`, `/docs-search`, `/docs-list`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-05-29
+
+A small release hygiene patch for the MCP hardening release. No API changes;
+no migration needed.
+
+### Fixed
+- **Runtime version now matches package metadata.** `docpull --version` and the
+  default HTTP `User-Agent` report `3.0.2` instead of the stale `3.0.0` value
+  that remained in `docpull.__version__` after the 3.0.1 publish.
+
+### Tests
+- **Added a stdio MCP smoke test.** The test starts `docpull mcp` through the
+  official MCP client, verifies the advertised 8-tool surface, checks
+  structured `list_sources` output, and confirms SSRF rejection still flows
+  through a real MCP `call_tool` request.
+
 ## [3.0.1] - 2026-05-29
 
 A security and correctness patch. No API changes; no migration needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "3.0.1"
+version = "3.0.2"
 dynamic = []
 description = "Pull documentation from the web and convert to clean markdown"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "3.0.0"
+__version__ = "3.0.2"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .conversion.chunking import Chunk, TokenCounter, chunk_markdown

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,15 @@
 """CLI regression tests."""
 
+from importlib.metadata import version
+
 import pytest
 
+import docpull
 from docpull.cli import create_parser
+
+
+def test_runtime_version_matches_package_metadata():
+    assert docpull.__version__ == version("docpull")
 
 
 def test_parser_rejects_removed_js_flag():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,51 @@
+"""End-to-end tests for the stdio MCP server."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+pytest.importorskip("mcp.client.stdio")
+
+from mcp.client.stdio import stdio_client
+
+from mcp import ClientSession, StdioServerParameters
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_lists_and_calls_tools(tmp_path):
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(tmp_path / "config")
+    env["XDG_DATA_HOME"] = str(tmp_path / "data")
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "docpull", "mcp"],
+        env=env,
+    )
+    async with stdio_client(server) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+
+        tools = await session.list_tools()
+        names = {tool.name for tool in tools.tools}
+        assert names == {
+            "fetch_url",
+            "ensure_docs",
+            "list_sources",
+            "list_indexed",
+            "grep_docs",
+            "read_doc",
+            "add_source",
+            "remove_source",
+        }
+
+        result = await session.call_tool("list_sources", {})
+        assert result.isError is False
+        assert result.structuredContent is not None
+        assert any(source["name"] == "react" for source in result.structuredContent["sources"])
+
+        rejected = await session.call_tool("fetch_url", {"url": "https://localhost/admin"})
+        assert rejected.isError is True


### PR DESCRIPTION
## Summary
- bump docpull to 3.0.2 and sync runtime __version__ with package metadata
- document Claude Code and Cursor stdio MCP setup in the README
- add version drift coverage and a real stdio MCP smoke test for the 8-tool surface

## Verification
- .venv/bin/ruff check .
- .venv/bin/python -m pytest -q
- .venv/bin/python -m docpull --version