### PR TITLE
Add durable run metadata and frontier state

### DIFF
--- a/src/docpull/cache/__init__.py
+++ b/src/docpull/cache/__init__.py
@@ -1,5 +1,6 @@
 """Caching and deduplication for docpull."""
 
+from .frontier import FrontierEntry, FrontierState, FrontierStore
 from .manager import DEFAULT_TTL_DAYS, CacheManager, CacheState, ManifestEntry
 from .streaming_dedup import StreamingDeduplicator
 
@@ -7,6 +8,9 @@ __all__ = [
     "CacheManager",
     "CacheState",
     "ManifestEntry",
+    "FrontierEntry",
+    "FrontierState",
+    "FrontierStore",
     "StreamingDeduplicator",
     "DEFAULT_TTL_DAYS",
 ]

--- a/src/docpull/cache/frontier.py
+++ b/src/docpull/cache/frontier.py
@@ -1,0 +1,199 @@
+"""Durable crawl frontier state for pause/resume and provenance."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..models.run import FRONTIER_SCHEMA_VERSION
+from ..time_utils import utc_now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class FrontierState(str, Enum):
+    """Lifecycle state for a URL in the crawl frontier."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    SUCCEEDED = "succeeded"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+@dataclass
+class FrontierEntry:
+    url: str
+    state: FrontierState = FrontierState.QUEUED
+    depth: int | None = None
+    source: str | None = None
+    discovered_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    attempts: int = 0
+    last_error: str | None = None
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> FrontierEntry | None:
+        url = data.get("url")
+        if not isinstance(url, str):
+            return None
+        try:
+            state = FrontierState(str(data.get("state", FrontierState.QUEUED.value)))
+        except ValueError:
+            state = FrontierState.QUEUED
+        attempts = data.get("attempts")
+        discovered_at = data.get("discovered_at")
+        updated_at = data.get("updated_at")
+        return cls(
+            url=url,
+            state=state,
+            depth=data.get("depth") if isinstance(data.get("depth"), int) else None,
+            source=data.get("source") if isinstance(data.get("source"), str) else None,
+            discovered_at=discovered_at if isinstance(discovered_at, str) else utc_now_iso(),
+            updated_at=updated_at if isinstance(updated_at, str) else utc_now_iso(),
+            attempts=attempts if isinstance(attempts, int) else 0,
+            last_error=data.get("last_error") if isinstance(data.get("last_error"), str) else None,
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "url": self.url,
+            "state": self.state.value,
+            "depth": self.depth,
+            "source": self.source,
+            "discovered_at": self.discovered_at,
+            "updated_at": self.updated_at,
+            "attempts": self.attempts,
+            "last_error": self.last_error,
+        }
+
+
+class FrontierStore:
+    """Small JSON-backed frontier store.
+
+    The store is intentionally simple because docpull is single-process today.
+    It gives us explicit URL lifecycle state and a compatibility fingerprint
+    without introducing a queue service or SQLite dependency for markdown users.
+    """
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.entries: dict[str, FrontierEntry] = {}
+        self.start_url: str | None = None
+        self.run_fingerprint: dict[str, object] | None = None
+        self.created_at: str | None = None
+        self.updated_at: str | None = None
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            logger.warning("Could not load frontier store %s: %s", self.path, err)
+            return
+        if not isinstance(data, dict) or data.get("schema_version") != FRONTIER_SCHEMA_VERSION:
+            return
+        entries = data.get("entries")
+        if not isinstance(entries, list):
+            return
+        self.start_url = data.get("start_url") if isinstance(data.get("start_url"), str) else None
+        fingerprint = data.get("run_fingerprint")
+        self.run_fingerprint = fingerprint if isinstance(fingerprint, dict) else None
+        self.created_at = data.get("created_at") if isinstance(data.get("created_at"), str) else None
+        self.updated_at = data.get("updated_at") if isinstance(data.get("updated_at"), str) else None
+        for item in entries:
+            if not isinstance(item, dict):
+                continue
+            entry = FrontierEntry.from_json(item)
+            if entry:
+                self.entries[entry.url] = entry
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        now = utc_now_iso()
+        if self.created_at is None:
+            self.created_at = now
+        self.updated_at = now
+        data = {
+            "schema_version": FRONTIER_SCHEMA_VERSION,
+            "start_url": self.start_url,
+            "run_fingerprint": self.run_fingerprint,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "entries": [entry.to_json() for entry in self.entries.values()],
+        }
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            tmp.replace(self.path)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def initialize(self, *, start_url: str, run_fingerprint: dict[str, object]) -> None:
+        if self.start_url != start_url or self.run_fingerprint != run_fingerprint:
+            self.entries.clear()
+            self.created_at = utc_now_iso()
+        self.start_url = start_url
+        self.run_fingerprint = run_fingerprint
+        self.save()
+
+    def compatible(self, *, start_url: str, run_fingerprint: dict[str, object]) -> bool:
+        return self.start_url == start_url and self.run_fingerprint == run_fingerprint
+
+    def add(self, url: str, *, depth: int | None = None, source: str | None = None) -> None:
+        if url in self.entries:
+            return
+        self.entries[url] = FrontierEntry(url=url, depth=depth, source=source)
+
+    def add_many(self, urls: list[str], *, source: str | None = None) -> None:
+        for url in urls:
+            self.add(url, source=source)
+
+    def mark_processing(self, url: str) -> None:
+        entry = self.entries.get(url)
+        if not entry:
+            self.add(url)
+            entry = self.entries[url]
+        entry.state = FrontierState.PROCESSING
+        entry.attempts += 1
+        entry.updated_at = utc_now_iso()
+        self.save()
+
+    def mark_succeeded(self, url: str) -> None:
+        self._mark_terminal(url, FrontierState.SUCCEEDED)
+
+    def mark_skipped(self, url: str) -> None:
+        self._mark_terminal(url, FrontierState.SKIPPED)
+
+    def mark_failed(self, url: str, error: str | None = None) -> None:
+        self._mark_terminal(url, FrontierState.FAILED, error=error)
+
+    def _mark_terminal(self, url: str, state: FrontierState, error: str | None = None) -> None:
+        entry = self.entries.get(url)
+        if not entry:
+            self.add(url)
+            entry = self.entries[url]
+        entry.state = state
+        entry.last_error = error
+        entry.updated_at = utc_now_iso()
+        self.save()
+
+    def pending_urls(self) -> list[str]:
+        terminal = {FrontierState.SUCCEEDED, FrontierState.SKIPPED}
+        return [url for url, entry in self.entries.items() if entry.state not in terminal]
+
+    def clear(self) -> None:
+        if self.path.exists():
+            self.path.unlink()
+        self.entries.clear()
+        self.start_url = None
+        self.run_fingerprint = None
+        self.created_at = None
+        self.updated_at = None

--- a/src/docpull/cache/manager.py
+++ b/src/docpull/cache/manager.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import tempfile
 from datetime import timedelta
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from ..time_utils import parse_persisted_datetime, utc_now, utc_now_iso
+from .frontier import FrontierStore
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,8 @@ class ManifestEntry(TypedDict, total=False):
     size: int
     etag: str
     last_modified: str
+    schema_version: int
+    run_fingerprint: dict[str, Any]
 
 
 class CacheState(TypedDict, total=False):
@@ -41,6 +45,7 @@ class DiscoveredUrlsState(TypedDict, total=False):
 
     start_url: str
     discovered_at: str
+    config_fingerprint: dict[str, Any]
     urls: list[str]
 
 
@@ -56,18 +61,26 @@ class _InternalState:
     def from_cache_state(cls, state: CacheState) -> _InternalState:
         """Create internal state from serialized CacheState."""
         internal = cls()
-        internal.fetched_urls = set(state.get("fetched_urls", []))
-        internal.failed_urls = set(state.get("failed_urls", []))
-        internal.last_run = state.get("last_run")
+        internal.fetched_urls = set(_string_list(state.get("fetched_urls")))
+        internal.failed_urls = set(_string_list(state.get("failed_urls")))
+        last_run = state.get("last_run")
+        internal.last_run = last_run if isinstance(last_run, str) else None
         return internal
 
     def to_cache_state(self) -> CacheState:
         """Convert to serializable CacheState."""
         return {
-            "fetched_urls": list(self.fetched_urls),
-            "failed_urls": list(self.failed_urls),
+            "fetched_urls": sorted(self.fetched_urls),
+            "failed_urls": sorted(self.failed_urls),
             "last_run": self.last_run,
         }
+
+
+def _string_list(value: object) -> list[str]:
+    """Return only string items from a persisted JSON list."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
 
 
 class CacheManager:
@@ -94,6 +107,8 @@ class CacheManager:
         self.manifest_file = self.cache_dir / "manifest.json"
         self.state_file = self.cache_dir / "state.json"
         self.discovered_urls_file = self.cache_dir / "discovered_urls.json"
+        self.frontier_file = self.cache_dir / "frontier.json"
+        self.frontier = FrontierStore(self.frontier_file)
 
         self.manifest: dict[str, ManifestEntry] = self._load_manifest()
         self._state: _InternalState = _InternalState.from_cache_state(self._load_state())
@@ -111,20 +126,63 @@ class CacheManager:
         if self.manifest_file.exists():
             try:
                 with open(self.manifest_file, encoding="utf-8") as f:
-                    data: dict[str, ManifestEntry] = json.load(f)
-                    return data
+                    data: Any = json.load(f)
+                if not isinstance(data, dict):
+                    msg = "manifest root is not an object"
+                    raise ValueError(msg)
+                manifest: dict[str, ManifestEntry] = {}
+                for url, raw_entry in data.items():
+                    if not isinstance(url, str) or not isinstance(raw_entry, dict):
+                        logger.warning("Skipping invalid cache manifest entry for %r", url)
+                        continue
+                    entry: ManifestEntry = {}
+                    for key in ("checksum", "file_path", "fetched_at", "etag", "last_modified"):
+                        value = raw_entry.get(key)
+                        if isinstance(value, str):
+                            entry[key] = value  # type: ignore[literal-required]
+                    size = raw_entry.get("size")
+                    if isinstance(size, int):
+                        entry["size"] = size
+                    schema_version = raw_entry.get("schema_version")
+                    if isinstance(schema_version, int):
+                        entry["schema_version"] = schema_version
+                    run_fingerprint = raw_entry.get("run_fingerprint")
+                    if isinstance(run_fingerprint, dict):
+                        entry["run_fingerprint"] = run_fingerprint
+                    manifest[url] = entry
+                return manifest
             except Exception as e:
                 logger.warning(f"Could not load manifest: {e}")
 
         return {}
+
+    def _write_json(self, path: Path, data: object) -> None:
+        """Atomically write JSON data to a cache file."""
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.cache_dir,
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as f:
+                temp_path = Path(f.name)
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            temp_path.replace(path)
+        except Exception:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise
 
     def _save_manifest(self) -> None:
         """Save manifest to disk (internal, called by flush)."""
         if not self._manifest_dirty:
             return
         try:
-            with open(self.manifest_file, "w", encoding="utf-8") as f:
-                json.dump(self.manifest, f, indent=2, ensure_ascii=False)
+            self._write_json(self.manifest_file, self.manifest)
             self._manifest_dirty = False
         except Exception as e:
             logger.error(f"Could not save manifest: {e}")
@@ -138,8 +196,16 @@ class CacheManager:
         if self.state_file.exists():
             try:
                 with open(self.state_file, encoding="utf-8") as f:
-                    data: CacheState = json.load(f)
-                    return data
+                    data: Any = json.load(f)
+                if not isinstance(data, dict):
+                    msg = "state root is not an object"
+                    raise ValueError(msg)
+                last_run = data.get("last_run")
+                return {
+                    "fetched_urls": _string_list(data.get("fetched_urls")),
+                    "failed_urls": _string_list(data.get("failed_urls")),
+                    "last_run": last_run if isinstance(last_run, str) else None,
+                }
             except Exception as e:
                 logger.warning(f"Could not load state: {e}")
 
@@ -155,8 +221,7 @@ class CacheManager:
             return
         try:
             state = self._state.to_cache_state()
-            with open(self.state_file, "w", encoding="utf-8") as f:
-                json.dump(state, f, indent=2, ensure_ascii=False)
+            self._write_json(self.state_file, state)
             self._state_dirty = False
         except Exception as e:
             logger.error(f"Could not save state: {e}")
@@ -197,6 +262,12 @@ class CacheManager:
             content = content.encode("utf-8")
         return hashlib.sha256(content).hexdigest()
 
+    @staticmethod
+    def _content_size(content: str | bytes) -> int:
+        if isinstance(content, str):
+            return len(content.encode("utf-8"))
+        return len(content)
+
     def update_cache(
         self,
         url: str,
@@ -204,6 +275,7 @@ class CacheManager:
         file_path: Path,
         etag: str | None = None,
         last_modified: str | None = None,
+        run_fingerprint: dict[str, Any] | None = None,
     ) -> None:
         """Update cache entry for a URL.
 
@@ -221,8 +293,11 @@ class CacheManager:
             "checksum": self.compute_checksum(content),
             "file_path": str(file_path),
             "fetched_at": utc_now_iso(),
-            "size": len(content),
+            "size": self._content_size(content),
+            "schema_version": 1,
         }
+        if run_fingerprint is not None:
+            self.manifest[url]["run_fingerprint"] = run_fingerprint
 
         if etag:
             self.manifest[url]["etag"] = etag
@@ -241,6 +316,8 @@ class CacheManager:
             Changes are batched. Call flush() to persist to disk.
         """
         self._state.fetched_urls.add(url)
+        self._state.failed_urls.discard(url)
+        self.frontier.mark_succeeded(url)
         self._state_dirty = True
 
     def mark_failed(self, url: str) -> None:
@@ -253,6 +330,8 @@ class CacheManager:
             Changes are batched. Call flush() to persist to disk.
         """
         self._state.failed_urls.add(url)
+        self._state.fetched_urls.discard(url)
+        self.frontier.mark_failed(url)
         self._state_dirty = True
 
     def get_fetched_urls(self) -> set[str]:
@@ -302,14 +381,23 @@ class CacheManager:
             del self.manifest[url]
 
         if to_remove:
+            for url in to_remove:
+                self._state.fetched_urls.discard(url)
+                self._state.failed_urls.discard(url)
             self._manifest_dirty = True
+            self._state_dirty = True
             logger.info(f"Evicted {len(to_remove)} expired cache entries")
 
         return len(to_remove)
 
     # Resume capability methods
 
-    def save_discovered_urls(self, urls: list[str], start_url: str) -> None:
+    def save_discovered_urls(
+        self,
+        urls: list[str],
+        start_url: str,
+        config_fingerprint: dict[str, Any] | None = None,
+    ) -> None:
         """Save discovered URLs for resume capability.
 
         Args:
@@ -325,14 +413,22 @@ class CacheManager:
             "discovered_at": utc_now_iso(),
             "urls": urls,
         }
+        if config_fingerprint is not None:
+            data["config_fingerprint"] = config_fingerprint
+            self.frontier.initialize(start_url=start_url, run_fingerprint=config_fingerprint)
+        self.frontier.add_many(urls, source="discovery")
+        self.frontier.save()
         try:
-            with open(self.discovered_urls_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False)
+            self._write_json(self.discovered_urls_file, data)
             logger.info(f"Saved {len(urls)} discovered URLs for resume capability")
         except Exception as e:
             logger.error(f"Could not save discovered URLs: {e}")
 
-    def load_discovered_urls(self, start_url: str) -> list[str] | None:
+    def load_discovered_urls(
+        self,
+        start_url: str,
+        config_fingerprint: dict[str, Any] | None = None,
+    ) -> list[str] | None:
         """Load previously discovered URLs if they match the start URL.
 
         Args:
@@ -346,20 +442,32 @@ class CacheManager:
 
         try:
             with open(self.discovered_urls_file, encoding="utf-8") as f:
-                data: DiscoveredUrlsState = json.load(f)
+                data: Any = json.load(f)
+            if not isinstance(data, dict):
+                msg = "discovered URLs root is not an object"
+                raise ValueError(msg)
 
             if data.get("start_url") != start_url:
                 logger.info("Discovered URLs file exists but start_url doesn't match")
                 return None
+            if config_fingerprint is not None:
+                persisted_fingerprint = data.get("config_fingerprint")
+                if isinstance(persisted_fingerprint, dict) and persisted_fingerprint != config_fingerprint:
+                    logger.info("Discovered URLs file exists but crawl fingerprint doesn't match")
+                    return None
 
-            urls = data.get("urls", [])
+            urls = _string_list(data.get("urls"))
             logger.info(f"Loaded {len(urls)} discovered URLs from previous run")
             return urls
         except Exception as e:
             logger.warning(f"Could not load discovered URLs: {e}")
             return None
 
-    def get_pending_urls(self, start_url: str) -> list[str] | None:
+    def get_pending_urls(
+        self,
+        start_url: str,
+        config_fingerprint: dict[str, Any] | None = None,
+    ) -> list[str] | None:
         """Get URLs that were discovered but not yet fetched.
 
         Args:
@@ -368,7 +476,15 @@ class CacheManager:
         Returns:
             List of pending URLs, or None if no resume data available
         """
-        discovered = self.load_discovered_urls(start_url)
+        if config_fingerprint is not None and self.frontier.compatible(
+            start_url=start_url,
+            run_fingerprint=config_fingerprint,
+        ):
+            pending = self.frontier.pending_urls()
+            logger.info("Found %d pending URLs from frontier", len(pending))
+            return pending
+
+        discovered = self.load_discovered_urls(start_url, config_fingerprint=config_fingerprint)
         if discovered is None:
             return None
 
@@ -390,3 +506,4 @@ class CacheManager:
                 logger.info("Cleared discovered URLs file")
             except Exception as e:
                 logger.warning(f"Could not clear discovered URLs file: {e}")
+        self.frontier.clear()

--- a/src/docpull/cli.py
+++ b/src/docpull/cli.py
@@ -594,9 +594,21 @@ def run_fetcher(args: argparse.Namespace) -> int:
                             elif event.type == EventType.DISCOVERY_COMPLETE:
                                 progress.update(task, description=f"[green]Found {event.total} URLs")
                             elif event.type == EventType.FETCH_PROGRESS:
+                                processed = (
+                                    event.processed_count
+                                    if event.processed_count is not None
+                                    else event.current
+                                )
+                                total = event.total if event.total is not None else "?"
+                                saved = event.saved_count if event.saved_count is not None else "?"
+                                skipped = event.skipped_count if event.skipped_count is not None else "?"
+                                failed = event.failed_count if event.failed_count is not None else "?"
                                 progress.update(
                                     task,
-                                    description=f"[cyan]Fetching {event.current}/{event.total}: {event.url}",
+                                    description=(
+                                        f"[cyan]Processed {processed}/{total} "
+                                        f"(saved {saved}, skipped {skipped}, failed {failed}): {event.url}"
+                                    ),
                                 )
                             elif event.type == EventType.FETCH_SKIPPED:
                                 if event.skip_reason:

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -17,6 +17,7 @@ from ..http import AdaptiveRateLimiter, AsyncHttpClient, PerHostRateLimiter
 from ..models.config import DocpullConfig
 from ..models.events import EventType, FetchEvent, FetchStats, SkipReason
 from ..models.profiles import apply_profile
+from ..models.run import RunIdentity
 from ..pipeline.base import FetchPipeline, PageContext
 from ..pipeline.base import FetchStep as FetchStepProtocol
 from ..pipeline.steps import (
@@ -172,6 +173,7 @@ class Fetcher:
                     Profile defaults will be applied automatically.
         """
         self.config = apply_profile(config)
+        self.run_identity = RunIdentity.from_config(self.config)
         self._cancelled = False
         self._stats = FetchStats()
         self._start_time: float | None = None
@@ -189,6 +191,30 @@ class Fetcher:
         self._sqlite_saver: SqliteSaveStep | None = None
         self._ndjson_saver: NdjsonSaveStep | None = None
         self._save_step: SaveStep | None = None
+
+    def _run_fingerprint(self) -> dict[str, object]:
+        return self.run_identity.fingerprint()
+
+    @staticmethod
+    def _update_progress_counts(counts: dict[str, int], ctx: PageContext | None = None) -> None:
+        counts["processed"] += 1
+        if ctx is None or ctx.error:
+            counts["failed"] += 1
+        elif ctx.should_skip:
+            counts["skipped"] += 1
+        else:
+            counts["saved"] += 1
+
+    @staticmethod
+    def _progress_event(url: str, counts: dict[str, int], total: int | None) -> FetchEvent:
+        return FetchEvent.progress(
+            url=url,
+            processed=counts["processed"],
+            total=total,
+            saved=counts["saved"],
+            skipped=counts["skipped"],
+            failed=counts["failed"],
+        )
 
     @property
     def stats(self) -> FetchStats:
@@ -358,17 +384,18 @@ class Fetcher:
 
         # Add appropriate save step based on output format
         if self.config.output.format == "json":
-            self._json_saver = JsonSaveStep(base_output_dir=output_dir)
+            self._json_saver = JsonSaveStep(base_output_dir=output_dir, run_identity=self.run_identity)
             steps.append(self._json_saver)
         elif self.config.output.format == "ndjson":
             self._ndjson_saver = NdjsonSaveStep(
                 base_output_dir=output_dir,
                 filename=self.config.output.ndjson_filename,
                 emit_chunks=self.config.output.emit_chunks,
+                run_identity=self.run_identity,
             )
             steps.append(self._ndjson_saver)
         elif self.config.output.format == "sqlite":
-            self._sqlite_saver = SqliteSaveStep(base_output_dir=output_dir)
+            self._sqlite_saver = SqliteSaveStep(base_output_dir=output_dir, run_identity=self.run_identity)
             steps.append(self._sqlite_saver)
         else:
             # Default to markdown file output. SaveStep also writes
@@ -613,7 +640,10 @@ class Fetcher:
             or not self.config.url
         ):
             return None
-        pending = self._cache_manager.get_pending_urls(self.config.url)
+        pending = self._cache_manager.get_pending_urls(
+            self.config.url,
+            config_fingerprint=self._run_fingerprint(),
+        )
         if pending is None:
             return None
         max_pages = self.config.crawl.max_pages
@@ -641,7 +671,11 @@ class Fetcher:
                 return
 
         if self.config.cache.enabled and self._cache_manager:
-            self._cache_manager.save_discovered_urls(discovered, start_url)
+            self._cache_manager.save_discovered_urls(
+                discovered,
+                start_url,
+                config_fingerprint=self._run_fingerprint(),
+            )
 
         yield FetchEvent(
             type=EventType.DISCOVERY_COMPLETE,
@@ -662,24 +696,17 @@ class Fetcher:
         assert self._pipeline is not None
         assert self._start_time is not None
         self._stats.urls_discovered = len(urls)
+        progress_counts = {"processed": 0, "saved": 0, "skipped": 0, "failed": 0}
 
         collected_events: list[FetchEvent] = []
 
         def collect(event: FetchEvent) -> None:
             collected_events.append(event)
 
-        for i, url in enumerate(urls):
+        for url in urls:
             if self._cancelled:
                 yield FetchEvent(type=EventType.CANCELLED, message="Fetch cancelled by user")
                 return
-
-            yield FetchEvent(
-                type=EventType.FETCH_PROGRESS,
-                url=url,
-                current=i + 1,
-                total=len(urls),
-                message=f"Processing {i + 1}/{len(urls)}: {url}",
-            )
 
             if self.config.dry_run:
                 yield FetchEvent(
@@ -690,14 +717,28 @@ class Fetcher:
                     skip_reason=SkipReason.DRY_RUN,
                 )
                 self._stats.pages_skipped += 1
+                self._update_progress_counts(
+                    progress_counts,
+                    PageContext(
+                        url=url,
+                        output_path=self._compute_output_path(url),
+                        should_skip=True,
+                    ),
+                )
+                yield self._progress_event(url, progress_counts, len(urls))
                 continue
 
             output_path = self._compute_output_path(url)
             collected_events.clear()
-            ctx = await self._pipeline.execute(url, output_path, emit=collect)
+            if self._cache_manager:
+                self._cache_manager.frontier.mark_processing(url)
+            result = await self._pipeline.execute_result(url, output_path, emit=collect)
+            ctx = result.ctx
             for ev in collected_events:
                 yield ev
             self._record_result(url, output_path, ctx)
+            self._update_progress_counts(progress_counts, ctx)
+            yield self._progress_event(url, progress_counts, len(urls))
 
         self._stats.duration_seconds = time.monotonic() - self._start_time
         if self._cache_manager and self._stats.pages_failed == 0:
@@ -736,7 +777,7 @@ class Fetcher:
         url_queue: asyncio.Queue[str | None] = asyncio.Queue(maxsize=worker_count * 4)
         event_queue: asyncio.Queue[FetchEvent | None] = asyncio.Queue()
 
-        progress_counter = {"saved": 0}
+        progress_counter = {"processed": 0, "saved": 0, "skipped": 0, "failed": 0}
 
         async def discover_into_queue() -> None:
             discovered_for_resume: list[str] = []
@@ -759,10 +800,18 @@ class Fetcher:
                         and self._cache_manager
                         and len(discovered_for_resume) % 200 == 0
                     ):
-                        self._cache_manager.save_discovered_urls(list(discovered_for_resume), start_url)
+                        self._cache_manager.save_discovered_urls(
+                            list(discovered_for_resume),
+                            start_url,
+                            config_fingerprint=self._run_fingerprint(),
+                        )
             finally:
                 if self.config.cache.enabled and self._cache_manager:
-                    self._cache_manager.save_discovered_urls(discovered_for_resume, start_url)
+                    self._cache_manager.save_discovered_urls(
+                        discovered_for_resume,
+                        start_url,
+                        config_fingerprint=self._run_fingerprint(),
+                    )
                 self._stats.urls_discovered = len(discovered_for_resume)
                 await event_queue.put(
                     FetchEvent(
@@ -792,6 +841,10 @@ class Fetcher:
                         )
                     )
                     self._stats.pages_skipped += 1
+                    skipped_ctx = PageContext(url=url, output_path=output_path, should_skip=True)
+                    self._update_progress_counts(progress_counter, skipped_ctx)
+                    total_so_far = self._stats.urls_discovered or progress_counter["processed"]
+                    await event_queue.put(self._progress_event(url, progress_counter, total_so_far))
                     continue
 
                 local_events: list[FetchEvent] = []
@@ -803,7 +856,10 @@ class Fetcher:
                     _sink.append(ev)
 
                 try:
-                    ctx = await pipeline.execute(url, output_path, emit=emit)
+                    if self._cache_manager:
+                        self._cache_manager.frontier.mark_processing(url)
+                    result = await pipeline.execute_result(url, output_path, emit=emit)
+                    ctx = result.ctx
                 except Exception as err:  # noqa: BLE001
                     await event_queue.put(
                         FetchEvent(
@@ -814,26 +870,18 @@ class Fetcher:
                         )
                     )
                     self._stats.pages_failed += 1
+                    self._update_progress_counts(progress_counter)
+                    total_so_far = self._stats.urls_discovered or progress_counter["processed"]
+                    await event_queue.put(self._progress_event(url, progress_counter, total_so_far))
                     continue
 
                 for ev in local_events:
                     await event_queue.put(ev)
 
                 self._record_result(url, output_path, ctx)
-                if ctx.markdown and not ctx.error and not ctx.should_skip:
-                    progress_counter["saved"] += 1
-                    # Synthesize a progress event so the CLI bar moves;
-                    # `total` may still be unknown, so report what we know.
-                    total_so_far = self._stats.urls_discovered or progress_counter["saved"]
-                    await event_queue.put(
-                        FetchEvent(
-                            type=EventType.FETCH_PROGRESS,
-                            url=url,
-                            current=progress_counter["saved"],
-                            total=total_so_far,
-                            message=f"Saved {progress_counter['saved']}/{total_so_far}: {url}",
-                        )
-                    )
+                self._update_progress_counts(progress_counter, ctx)
+                total_so_far = self._stats.urls_discovered or progress_counter["processed"]
+                await event_queue.put(self._progress_event(url, progress_counter, total_so_far))
 
         discover_task = asyncio.create_task(discover_into_queue())
         worker_tasks = [asyncio.create_task(worker()) for _ in range(worker_count)]
@@ -884,7 +932,11 @@ class Fetcher:
                 self._cache_manager.mark_failed(url)
             return
         if ctx.should_skip:
+            if ctx.skip_code == SkipReason.DUPLICATE_CONTENT:
+                self._stats.pages_deduplicated += 1
             self._stats.pages_skipped += 1
+            if self._cache_manager:
+                self._cache_manager.frontier.mark_skipped(url)
             return
         self._stats.pages_fetched += 1
         self._stats.bytes_downloaded += ctx.bytes_downloaded
@@ -893,9 +945,10 @@ class Fetcher:
             self._cache_manager.update_cache(
                 url=url,
                 content=ctx.markdown,
-                file_path=output_path,
+                file_path=ctx.persisted_path or output_path,
                 etag=ctx.etag,
                 last_modified=ctx.last_modified,
+                run_fingerprint=self._run_fingerprint(),
             )
             self._cache_manager.mark_fetched(url)
 

--- a/src/docpull/mcp/tools.py
+++ b/src/docpull/mcp/tools.py
@@ -26,6 +26,7 @@ import yaml
 
 from ..core.fetcher import Fetcher
 from ..models.config import CrawlConfig, DocpullConfig, OutputConfig, ProfileName
+from ..models.run import MCP_META_SCHEMA_VERSION
 from ..security.url_validator import UrlValidator
 from ..time_utils import utc_now_iso
 from .sources import (
@@ -74,7 +75,13 @@ def _source_dir(docs_dir: Path, source: str) -> Path:
     return docs_dir / source
 
 
-def _cache_fresh(meta_path: Path) -> bool:
+def _cache_fresh(
+    meta_path: Path,
+    *,
+    expected_url: str | None = None,
+    expected_profile: str | None = None,
+    expected_max_pages: int | None = None,
+) -> bool:
     if not meta_path.exists():
         return False
     try:
@@ -86,10 +93,26 @@ def _cache_fresh(meta_path: Path) -> bool:
         return False
     if data.get("partial") is True:
         return False
+    if data.get("schema_version") != MCP_META_SCHEMA_VERSION:
+        return False
+    if expected_url is not None and data.get("url") != expected_url:
+        return False
+    if expected_profile is not None and data.get("profile") != expected_profile:
+        return False
+    if data.get("max_pages") != expected_max_pages:
+        return False
     return (time.time() - fetched_at) < CACHE_TTL_SECONDS
 
 
-def _write_meta(meta_path: Path, source: str, url: str, pages: int) -> None:
+def _write_meta(
+    meta_path: Path,
+    source: str,
+    url: str,
+    pages: int,
+    *,
+    profile: str,
+    max_pages: int | None,
+) -> None:
     """Atomic-ish meta write: tmp file + rename so a crash mid-write
     never leaves a half-parsed JSON behind."""
     meta_path.parent.mkdir(parents=True, exist_ok=True)
@@ -99,6 +122,9 @@ def _write_meta(meta_path: Path, source: str, url: str, pages: int) -> None:
             {
                 "source": source,
                 "url": url,
+                "schema_version": MCP_META_SCHEMA_VERSION,
+                "profile": profile,
+                "max_pages": max_pages,
                 "fetched_at_epoch": time.time(),
                 "fetched_at": utc_now_iso(),
                 "page_count": pages,
@@ -109,7 +135,15 @@ def _write_meta(meta_path: Path, source: str, url: str, pages: int) -> None:
     os.replace(tmp, meta_path)
 
 
-def _write_partial_meta(meta_path: Path, source: str, url: str, pages: int) -> None:
+def _write_partial_meta(
+    meta_path: Path,
+    source: str,
+    url: str,
+    pages: int,
+    *,
+    profile: str,
+    max_pages: int | None,
+) -> None:
     """Mark a fetch as partial. ``_cache_fresh`` treats partial as stale."""
     meta_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = meta_path.with_suffix(meta_path.suffix + ".tmp")
@@ -118,6 +152,9 @@ def _write_partial_meta(meta_path: Path, source: str, url: str, pages: int) -> N
             {
                 "source": source,
                 "url": url,
+                "schema_version": MCP_META_SCHEMA_VERSION,
+                "profile": profile,
+                "max_pages": max_pages,
                 "fetched_at_epoch": time.time(),
                 "fetched_at": utc_now_iso(),
                 "page_count": pages,
@@ -200,9 +237,19 @@ async def ensure_docs(
 
     target_dir = _source_dir(docs_dir, source)
     meta_path = _meta_path(docs_dir, source)
+    profile_name = profile_enum.value
 
-    if not force and _cache_fresh(meta_path) and target_dir.exists() and any(target_dir.rglob("*.md")):
-        files = list(target_dir.rglob("*.md"))
+    files = list(target_dir.rglob("*.md")) if target_dir.exists() else []
+    if (
+        not force
+        and files
+        and _cache_fresh(
+            meta_path,
+            expected_url=resolved.url,
+            expected_profile=profile_name,
+            expected_max_pages=resolved.max_pages,
+        )
+    ):
         return ToolResult(
             f"Cached: {source} ({len(files)} files at {target_dir}). Call with force=true to refresh.",
             data={
@@ -233,11 +280,25 @@ async def ensure_docs(
         crashed = True
         # Mark whatever made it to disk as a partial fetch so future
         # ensure_docs calls re-fetch instead of trusting half a crawl.
-        _write_partial_meta(meta_path, source, resolved.url, fetched)
+        _write_partial_meta(
+            meta_path,
+            source,
+            resolved.url,
+            fetched,
+            profile=profile_name,
+            max_pages=resolved.max_pages,
+        )
         raise
 
     if not crashed:
-        _write_meta(meta_path, source, resolved.url, stats.pages_fetched)
+        _write_meta(
+            meta_path,
+            source,
+            resolved.url,
+            stats.pages_fetched,
+            profile=profile_name,
+            max_pages=resolved.max_pages,
+        )
     return ToolResult(
         f"Fetched {source}: {stats.pages_fetched} pages saved to {target_dir} "
         f"({stats.pages_skipped} skipped, {stats.pages_failed} failed).",

--- a/src/docpull/models/__init__.py
+++ b/src/docpull/models/__init__.py
@@ -13,8 +13,17 @@ from .config import (
     PerformanceConfig,
     ProfileName,
 )
+from .document import DocumentRecord
 from .events import EventType, FetchEvent, FetchStats, SkipReason
 from .profiles import PROFILES, apply_profile
+from .run import (
+    DOCUMENT_RECORD_SCHEMA_VERSION,
+    FRONTIER_SCHEMA_VERSION,
+    MCP_META_SCHEMA_VERSION,
+    PROGRESS_EVENT_SCHEMA_VERSION,
+    RUN_IDENTITY_SCHEMA_VERSION,
+    RunIdentity,
+)
 
 __all__ = [
     # Config
@@ -29,6 +38,13 @@ __all__ = [
     "OutputConfig",
     "PerformanceConfig",
     "ProfileName",
+    "RunIdentity",
+    "DocumentRecord",
+    "RUN_IDENTITY_SCHEMA_VERSION",
+    "DOCUMENT_RECORD_SCHEMA_VERSION",
+    "FRONTIER_SCHEMA_VERSION",
+    "MCP_META_SCHEMA_VERSION",
+    "PROGRESS_EVENT_SCHEMA_VERSION",
     # Events
     "EventType",
     "FetchEvent",

--- a/src/docpull/models/document.py
+++ b/src/docpull/models/document.py
@@ -1,0 +1,58 @@
+"""Canonical document record emitted by all structured output sinks."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ..time_utils import utc_now_iso
+from .run import DOCUMENT_RECORD_SCHEMA_VERSION, RunIdentity
+
+
+class DocumentRecord(BaseModel):
+    """Versioned logical document shape independent of output container."""
+
+    schema_version: int = DOCUMENT_RECORD_SCHEMA_VERSION
+    url: str
+    title: str | None = None
+    content: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    extraction: dict[str, Any] = Field(default_factory=dict)
+    source_type: str | None = None
+    fetched_at: str = Field(default_factory=utc_now_iso)
+    content_hash: str
+    run: dict[str, Any] | None = None
+    chunk_index: int | None = None
+    chunk_heading: str | None = None
+    token_count: int | None = None
+
+    @classmethod
+    def from_page(
+        cls,
+        *,
+        url: str,
+        content: str,
+        title: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        extraction: dict[str, Any] | None = None,
+        source_type: str | None = None,
+        run_identity: RunIdentity | None = None,
+        chunk_index: int | None = None,
+        chunk_heading: str | None = None,
+        token_count: int | None = None,
+    ) -> DocumentRecord:
+        return cls(
+            url=url,
+            title=title,
+            content=content,
+            metadata=metadata or {},
+            extraction=extraction or {},
+            source_type=source_type,
+            content_hash=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            run=run_identity.model_dump(mode="json") if run_identity else None,
+            chunk_index=chunk_index,
+            chunk_heading=chunk_heading,
+            token_count=token_count,
+        )

--- a/src/docpull/models/events.py
+++ b/src/docpull/models/events.py
@@ -1,10 +1,13 @@
 """Event types for the streaming fetch API."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+
+from .run import PROGRESS_EVENT_SCHEMA_VERSION
 
 
 class SkipReason(str, Enum):
@@ -20,6 +23,10 @@ class SkipReason(str, Enum):
     HTTP_ERROR = "http_error"
     FILE_EXISTS = "file_exists"
     DRY_RUN = "dry_run"
+    URL_VALIDATION_FAILED = "url_validation_failed"
+    JS_ONLY_SPA = "js_only_spa"
+    NO_CONTENT_EXTRACTED = "no_content_extracted"
+    NO_CONTENT_TO_SAVE = "no_content_to_save"
 
 
 class EventType(str, Enum):
@@ -90,6 +97,11 @@ class FetchEvent:
     # Progress tracking
     current: int | None = None
     total: int | None = None
+    progress_schema_version: int | None = None
+    processed_count: int | None = None
+    saved_count: int | None = None
+    skipped_count: int | None = None
+    failed_count: int | None = None
 
     # Typed payload fields for specific events
     bytes_downloaded: int | None = None
@@ -98,7 +110,7 @@ class FetchEvent:
     content_type: str | None = None
     retry_attempt: int | None = None
     duplicate_of: str | None = None  # URL of original for dedup events
-    skip_reason: Optional["SkipReason"] = None  # Reason for skipping a URL
+    skip_reason: SkipReason | None = None  # Reason for skipping a URL
 
     @property
     def progress_percent(self) -> float | None:
@@ -116,6 +128,33 @@ class FetchEvent:
     def is_progress(self) -> bool:
         """Check if this is a progress event."""
         return self.type == EventType.FETCH_PROGRESS
+
+    @staticmethod
+    def progress(
+        *,
+        url: str,
+        processed: int,
+        total: int | None,
+        saved: int,
+        skipped: int,
+        failed: int,
+    ) -> FetchEvent:
+        total_for_message = total if total is not None else processed
+        return FetchEvent(
+            type=EventType.FETCH_PROGRESS,
+            url=url,
+            current=processed,
+            total=total,
+            progress_schema_version=PROGRESS_EVENT_SCHEMA_VERSION,
+            processed_count=processed,
+            saved_count=saved,
+            skipped_count=skipped,
+            failed_count=failed,
+            message=(
+                f"Processed {processed}/{total_for_message} "
+                f"(saved {saved}, skipped {skipped}, failed {failed}): {url}"
+            ),
+        )
 
 
 @dataclass

--- a/src/docpull/models/run.py
+++ b/src/docpull/models/run.py
@@ -1,0 +1,60 @@
+"""Run identity and artifact schema constants."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .config import DocpullConfig
+
+RUN_IDENTITY_SCHEMA_VERSION = 1
+DOCUMENT_RECORD_SCHEMA_VERSION = 1
+FRONTIER_SCHEMA_VERSION = 1
+MCP_META_SCHEMA_VERSION = 1
+PROGRESS_EVENT_SCHEMA_VERSION = 1
+
+
+class RunIdentity(BaseModel):
+    """Stable, non-secret description of the semantics of a docpull run."""
+
+    schema_version: int = RUN_IDENTITY_SCHEMA_VERSION
+    profile: str
+    start_url: str | None = None
+    max_pages: int | None = None
+    max_depth: int
+    include_paths: list[str] = Field(default_factory=list)
+    exclude_paths: list[str] = Field(default_factory=list)
+    output_format: str
+    naming_strategy: str
+    rich_metadata: bool
+    extractor: str
+    enable_special_cases: bool
+    strict_js_required: bool
+    max_tokens_per_file: int | None = None
+    emit_chunks: bool
+    tokenizer: str
+    auth_type: str
+
+    @classmethod
+    def from_config(cls, config: DocpullConfig) -> RunIdentity:
+        return cls(
+            profile=config.profile.value,
+            start_url=config.url,
+            max_pages=config.crawl.max_pages,
+            max_depth=config.crawl.max_depth,
+            include_paths=sorted(config.crawl.include_paths),
+            exclude_paths=sorted(config.crawl.exclude_paths),
+            output_format=config.output.format,
+            naming_strategy=config.output.naming_strategy,
+            rich_metadata=config.output.rich_metadata,
+            extractor=config.content_filter.extractor,
+            enable_special_cases=config.content_filter.enable_special_cases,
+            strict_js_required=config.content_filter.strict_js_required,
+            max_tokens_per_file=config.output.max_tokens_per_file,
+            emit_chunks=config.output.emit_chunks,
+            tokenizer=config.output.tokenizer,
+            auth_type=config.auth.type.value,
+        )
+
+    def fingerprint(self) -> dict[str, object]:
+        """Deterministic compatibility fingerprint for persisted state."""
+        return self.model_dump(mode="json", exclude_none=False)

--- a/src/docpull/pipeline/base.py
+++ b/src/docpull/pipeline/base.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
-from ..models.events import EventType, FetchEvent
+from ..models.events import EventType, FetchEvent, SkipReason
 
 # Type alias for event emitter function
 EventEmitter = Callable[[FetchEvent], None]
@@ -42,16 +43,19 @@ class PageContext:
     markdown: str | None = None
     metadata: dict = field(default_factory=dict)
     title: str | None = None
+    extraction_info: dict[str, Any] = field(default_factory=dict)
 
     # Status
     should_skip: bool = False
     skip_reason: str | None = None
+    skip_code: SkipReason | None = None
     error: str | None = None
 
     # Additional data from fetch
     status_code: int | None = None
     content_type: str | None = None
     bytes_downloaded: int = 0
+    persisted_path: Path | None = None
 
     # HTTP caching headers (for incremental updates)
     etag: str | None = None
@@ -60,6 +64,40 @@ class PageContext:
     # Framework detection and LLM-oriented output
     source_type: str | None = None
     chunks: list[object] = field(default_factory=list)
+
+    def mark_skipped(self, reason: str, code: SkipReason | None = None) -> None:
+        self.should_skip = True
+        self.skip_reason = reason
+        self.skip_code = code
+
+    def mark_failed(self, error: str) -> None:
+        self.error = error
+        self.should_skip = False
+
+
+class PipelineStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+@dataclass
+class PipelineResult:
+    ctx: PageContext
+    status: PipelineStatus
+    failed_step: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == PipelineStatus.SUCCEEDED
+
+    @property
+    def skipped(self) -> bool:
+        return self.status == PipelineStatus.SKIPPED
+
+    @property
+    def failed(self) -> bool:
+        return self.status == PipelineStatus.FAILED
 
 
 @runtime_checkable
@@ -140,12 +178,12 @@ class FetchPipeline:
 
     steps: list[FetchStep]
 
-    async def execute(
+    async def execute_result(
         self,
         url: str,
         output_path: Path,
         emit: EventEmitter | None = None,
-    ) -> PageContext:
+    ) -> PipelineResult:
         """
         Execute the pipeline for a URL.
 
@@ -155,19 +193,15 @@ class FetchPipeline:
             emit: Optional callback for emitting events
 
         Returns:
-            PageContext with final state (check error/should_skip for status)
+            PipelineResult with terminal status and final context.
         """
         ctx = PageContext(url=url, output_path=output_path)
 
         for step in self.steps:
-            if ctx.should_skip:
-                break
-
             try:
                 ctx = await step.execute(ctx, emit)
             except Exception as e:
-                ctx.error = f"{step.name}: {e}"
-                ctx.should_skip = True
+                ctx.mark_failed(f"{step.name}: {e}")
 
                 # Emit failure event
                 if emit:
@@ -178,6 +212,20 @@ class FetchPipeline:
                             error=ctx.error,
                         )
                     )
-                break
+                return PipelineResult(ctx=ctx, status=PipelineStatus.FAILED, failed_step=step.name)
 
-        return ctx
+            if ctx.error:
+                return PipelineResult(ctx=ctx, status=PipelineStatus.FAILED, failed_step=step.name)
+            if ctx.should_skip:
+                return PipelineResult(ctx=ctx, status=PipelineStatus.SKIPPED)
+
+        return PipelineResult(ctx=ctx, status=PipelineStatus.SUCCEEDED)
+
+    async def execute(
+        self,
+        url: str,
+        output_path: Path,
+        emit: EventEmitter | None = None,
+    ) -> PageContext:
+        """Compatibility wrapper returning only the final context."""
+        return (await self.execute_result(url, output_path, emit)).ctx

--- a/src/docpull/pipeline/steps/convert.py
+++ b/src/docpull/pipeline/steps/convert.py
@@ -16,7 +16,7 @@ from ...conversion.special_cases import (
     looks_like_spa,
     looks_like_spa_output,
 )
-from ...models.events import EventType, FetchEvent
+from ...models.events import EventType, FetchEvent, SkipReason
 from ..base import EventEmitter, PageContext
 
 if TYPE_CHECKING:
@@ -150,23 +150,28 @@ class ConvertStep:
             return ctx
 
         if ctx.html is None:
-            ctx.error = "No HTML content to convert"
+            ctx.mark_failed("No HTML content to convert")
             if emit:
                 emit(FetchEvent(type=EventType.FETCH_FAILED, url=ctx.url, error=ctx.error))
             return ctx
 
         try:
             ctx.source_type = detect_source_type(ctx.html, ctx.url)
+            ctx.extraction_info["detected_source_type"] = ctx.source_type
 
             special_markdown = self._try_special_cases(ctx)
             if special_markdown is not None:
                 markdown = special_markdown
+                ctx.extraction_info["method"] = "special_case"
             elif self._trafilatura is not None:
                 markdown = self._trafilatura.extract(ctx.html, ctx.url)
+                ctx.extraction_info["method"] = "trafilatura"
             else:
                 assert self._extractor is not None
                 assert self._converter is not None
                 extracted_html = self._extractor.extract(ctx.html, ctx.url)
+                ctx.extraction_info["method"] = "generic"
+                ctx.extraction_info["extracted_html_bytes"] = len(extracted_html.encode("utf-8"))
                 if not extracted_html.strip():
                     return self._handle_empty_content(ctx, emit)
                 markdown = self._converter.convert(extracted_html, ctx.url)
@@ -204,6 +209,9 @@ class ConvertStep:
                 markdown = frontmatter + markdown
 
             ctx.markdown = markdown
+            ctx.extraction_info["markdown_bytes"] = len(markdown.encode("utf-8"))
+            ctx.extraction_info["heading_count"] = len(_extract_headings(markdown, max_level=6, limit=1000))
+            ctx.extraction_info["confidence"] = self._confidence(ctx)
 
             if emit:
                 emit(
@@ -218,7 +226,7 @@ class ConvertStep:
 
         except Exception as e:  # noqa: BLE001
             logger.error("Conversion failed for %s: %s", ctx.url, e)
-            ctx.error = f"Conversion failed: {e}"
+            ctx.mark_failed(f"Conversion failed: {e}")
             if emit:
                 emit(FetchEvent(type=EventType.FETCH_FAILED, url=ctx.url, error=ctx.error))
             return ctx
@@ -241,13 +249,16 @@ class ConvertStep:
                 for k, v in result.extra.items():
                     ctx.metadata.setdefault(k, v)
             logger.debug("Special-case %s matched for %s", extractor.name, ctx.url)
+            ctx.extraction_info["special_case"] = extractor.name
             return result.markdown
         return None
 
     def _handle_empty_content(self, ctx: PageContext, emit: EventEmitter | None) -> PageContext:
         is_spa = ctx.html is not None and looks_like_spa(ctx.html)
+        ctx.extraction_info["confidence"] = 0.0
+        ctx.extraction_info["empty_reason"] = "js_only_spa" if is_spa else "no_content_extracted"
         if self._strict_js_required and is_spa:
-            ctx.error = (
+            ctx.mark_failed(
                 "Page appears to be a JavaScript-only SPA; rendered content was empty. "
                 "docpull does not execute JavaScript. Either disable --strict-js-required "
                 "or fetch a server-rendered mirror."
@@ -255,8 +266,10 @@ class ConvertStep:
             if emit:
                 emit(FetchEvent(type=EventType.FETCH_FAILED, url=ctx.url, error=ctx.error))
             return ctx
-        ctx.should_skip = True
-        ctx.skip_reason = "JS-only SPA: no content without JS render" if is_spa else "No content extracted"
+        ctx.mark_skipped(
+            "JS-only SPA: no content without JS render" if is_spa else "No content extracted",
+            SkipReason.JS_ONLY_SPA if is_spa else SkipReason.NO_CONTENT_EXTRACTED,
+        )
         if is_spa:
             logger.warning("Likely JS-only SPA at %s (no server-rendered content)", ctx.url)
         else:
@@ -267,6 +280,26 @@ class ConvertStep:
                     type=EventType.FETCH_SKIPPED,
                     url=ctx.url,
                     message=ctx.skip_reason,
+                    skip_reason=ctx.skip_code,
                 )
             )
         return ctx
+
+    @staticmethod
+    def _confidence(ctx: PageContext) -> float:
+        """Cheap extraction quality signal for downstream consumers."""
+        markdown = ctx.markdown or ""
+        if not markdown.strip():
+            return 0.0
+        score = 0.35
+        if ctx.extraction_info.get("method") == "special_case":
+            score += 0.35
+        elif ctx.extraction_info.get("method") == "trafilatura":
+            score += 0.25
+        elif len(markdown) > 500:
+            score += 0.15
+        if ctx.extraction_info.get("heading_count", 0):
+            score += 0.15
+        if ctx.source_type and ctx.source_type != "generic":
+            score += 0.1
+        return min(1.0, round(score, 2))

--- a/src/docpull/pipeline/steps/dedup.py
+++ b/src/docpull/pipeline/steps/dedup.py
@@ -4,7 +4,7 @@ import logging
 
 from ...cache import StreamingDeduplicator
 from ...conversion.chunking import _strip_frontmatter
-from ...models.events import EventType, FetchEvent
+from ...models.events import EventType, FetchEvent, SkipReason
 from ..base import EventEmitter, PageContext
 
 logger = logging.getLogger(__name__)
@@ -83,10 +83,18 @@ class DedupStep:
         should_save, duplicate_of = await self._deduplicator.check_and_register(ctx.url, content)
 
         if not should_save and duplicate_of:
-            ctx.should_skip = True
-            ctx.skip_reason = f"Duplicate of {duplicate_of}"
+            ctx.mark_skipped(f"Duplicate of {duplicate_of}", SkipReason.DUPLICATE_CONTENT)
 
             if emit:
+                emit(
+                    FetchEvent(
+                        type=EventType.FETCH_SKIPPED,
+                        url=ctx.url,
+                        duplicate_of=duplicate_of,
+                        message=f"Duplicate content (original: {duplicate_of})",
+                        skip_reason=SkipReason.DUPLICATE_CONTENT,
+                    )
+                )
                 emit(
                     FetchEvent(
                         type=EventType.PAGE_DEDUPLICATED,

--- a/src/docpull/pipeline/steps/fetch.py
+++ b/src/docpull/pipeline/steps/fetch.py
@@ -1,6 +1,7 @@
 """FetchStep - HTTP fetching pipeline step."""
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...http.protocols import HttpClient
@@ -130,10 +131,12 @@ class FetchStep:
         entry = self._cache_manager.manifest.get(url)
         if not entry:
             return {}
+        persisted_file = entry.get("file_path")
+        persisted_exists = isinstance(persisted_file, str) and Path(persisted_file).exists()
         # Force a fresh body when the cache has us on record but the file
         # is missing. Otherwise a 304 would short-circuit to skip and we'd
         # never write the file the user expects.
-        if not output_path_exists:
+        if not output_path_exists and not persisted_exists:
             return {}
         headers: dict[str, str] = {}
         etag = self._sanitize_validator(entry.get("etag"))
@@ -200,8 +203,7 @@ class FetchStep:
             # distinct reason so the CLI summary can count "unchanged" hits
             # separately from "blocked by robots" or "JS-only SPA."
             if response.status_code == 304:
-                ctx.should_skip = True
-                ctx.skip_reason = "Not modified (304)"
+                ctx.mark_skipped("Not modified (304)", SkipReason.CACHE_UNCHANGED)
                 logger.debug(f"304 Not Modified: {url}")
                 if emit:
                     emit(
@@ -217,8 +219,7 @@ class FetchStep:
 
             # Check for client errors (skip, don't fail)
             if 400 <= response.status_code < 500:
-                ctx.should_skip = True
-                ctx.skip_reason = f"HTTP {response.status_code}"
+                ctx.mark_skipped(f"HTTP {response.status_code}", SkipReason.HTTP_ERROR)
                 logger.debug(f"Skipping {url}: HTTP {response.status_code}")
 
                 if emit:
@@ -228,14 +229,17 @@ class FetchStep:
                             url=url,
                             status_code=response.status_code,
                             message=f"Skipped: HTTP {response.status_code}",
+                            skip_reason=SkipReason.HTTP_ERROR,
                         )
                     )
                 return ctx
 
             # Validate content type
             if self._validate_content_type and not self._is_valid_content_type(response.content_type):
-                ctx.should_skip = True
-                ctx.skip_reason = f"Invalid content type: {response.content_type}"
+                ctx.mark_skipped(
+                    f"Invalid content type: {response.content_type}",
+                    SkipReason.INVALID_CONTENT_TYPE,
+                )
                 logger.debug(f"Skipping {url}: invalid content type {response.content_type}")
 
                 if emit:
@@ -245,6 +249,7 @@ class FetchStep:
                             url=url,
                             content_type=response.content_type,
                             message="Skipped: invalid content type",
+                            skip_reason=SkipReason.INVALID_CONTENT_TYPE,
                         )
                     )
                 return ctx

--- a/src/docpull/pipeline/steps/save.py
+++ b/src/docpull/pipeline/steps/save.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from ...models.events import EventType, FetchEvent
+from ...models.events import EventType, FetchEvent, SkipReason
 from ..base import EventEmitter, PageContext
 
 logger = logging.getLogger(__name__)
@@ -105,8 +105,7 @@ class SaveStep:
             # Fall back to raw HTML if no markdown conversion
             content = ctx.html.decode("utf-8", errors="replace")
         else:
-            ctx.should_skip = True
-            ctx.skip_reason = "No content to save"
+            ctx.mark_skipped("No content to save", SkipReason.NO_CONTENT_TO_SAVE)
             logger.warning(f"Skipping {url}: no content to save")
 
             if emit:
@@ -115,6 +114,7 @@ class SaveStep:
                         type=EventType.FETCH_SKIPPED,
                         url=url,
                         message="No content to save",
+                        skip_reason=SkipReason.NO_CONTENT_TO_SAVE,
                     )
                 )
             return ctx
@@ -132,11 +132,15 @@ class SaveStep:
                 parent = validated_path.parent
                 ext = validated_path.suffix or ".md"
                 width = max(2, len(str(len(ctx.chunks) - 1)))
+                first_chunk_path: Path | None = None
                 for chunk in ctx.chunks:
                     idx = getattr(chunk, "index", 0)
                     text = getattr(chunk, "text", "")
                     chunk_path = parent / f"{stem}.{idx:0{width}d}{ext}"
                     await asyncio.to_thread(chunk_path.write_text, text, encoding="utf-8")
+                    if first_chunk_path is None:
+                        first_chunk_path = chunk_path
+                ctx.persisted_path = first_chunk_path
                 logger.info("Saved %d chunks: %s.*%s", len(ctx.chunks), parent / stem, ext)
             else:
                 # Write full document (use asyncio.to_thread to avoid blocking)
@@ -145,6 +149,7 @@ class SaveStep:
                     content,
                     encoding="utf-8",
                 )
+                ctx.persisted_path = validated_path
                 logger.info(f"Saved: {validated_path}")
 
             # Snapshot the first successful page's metadata for SKILL.md.
@@ -166,8 +171,7 @@ class SaveStep:
 
         except ValueError as e:
             # Path validation error
-            ctx.error = str(e)
-            ctx.should_skip = True
+            ctx.mark_failed(str(e))
             logger.error(f"Path validation failed for {url}: {e}")
 
             if emit:
@@ -183,7 +187,7 @@ class SaveStep:
 
         except OSError as e:
             # File system error
-            ctx.error = f"Failed to save: {e}"
+            ctx.mark_failed(f"Failed to save: {e}")
             logger.error(f"Failed to save {url} to {output_path}: {e}")
 
             if emit:

--- a/src/docpull/pipeline/steps/save_json.py
+++ b/src/docpull/pipeline/steps/save_json.py
@@ -10,7 +10,9 @@ import tempfile
 from pathlib import Path
 from typing import TextIO
 
+from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent
+from ...models.run import RunIdentity
 from ...time_utils import utc_now_iso
 from ..base import EventEmitter, PageContext
 
@@ -49,6 +51,7 @@ class JsonSaveStep:
         self,
         base_output_dir: Path,
         filename: str = "documents.json",
+        run_identity: RunIdentity | None = None,
     ) -> None:
         """
         Initialize the JSON save step.
@@ -63,6 +66,7 @@ class JsonSaveStep:
         self._temp_file: TextIO | None = None
         self._temp_path: str | None = None
         self._first_doc = True
+        self._run_identity = run_identity
 
     def _ensure_temp_file(self) -> TextIO:
         """Create temp file for streaming writes if not already open."""
@@ -97,13 +101,16 @@ class JsonSaveStep:
         if ctx.should_skip or not ctx.markdown:
             return ctx
 
-        doc = {
-            "url": ctx.url,
-            "title": ctx.title,
-            "content": ctx.markdown,
-            "metadata": ctx.metadata,
-            "fetched_at": utc_now_iso(),
-        }
+        record = DocumentRecord.from_page(
+            url=ctx.url,
+            title=ctx.title,
+            content=ctx.markdown,
+            metadata=ctx.metadata,
+            extraction=ctx.extraction_info,
+            source_type=ctx.source_type,
+            run_identity=self._run_identity,
+        )
+        doc = record.model_dump(mode="json", exclude_none=True)
 
         f = self._ensure_temp_file()
 
@@ -119,6 +126,7 @@ class JsonSaveStep:
         f.write(indented)
 
         self._document_count += 1
+        ctx.persisted_path = self._output_file
 
         if emit:
             emit(
@@ -142,7 +150,9 @@ class JsonSaveStep:
             # No documents written - create empty structure
             self._base_dir.mkdir(parents=True, exist_ok=True)
             output = {
+                "schema_version": 1,
                 "generated_at": utc_now_iso(),
+                "run": self._run_identity.model_dump(mode="json") if self._run_identity else None,
                 "document_count": 0,
                 "documents": [],
             }
@@ -154,7 +164,11 @@ class JsonSaveStep:
         try:
             # Close the documents array and add metadata
             self._temp_file.write("\n  ],\n")
+            self._temp_file.write('  "schema_version": 1,\n')
             self._temp_file.write(f'  "generated_at": "{utc_now_iso()}",\n')
+            if self._run_identity:
+                run_json = json.dumps(self._run_identity.model_dump(mode="json"), ensure_ascii=False)
+                self._temp_file.write(f'  "run": {run_json},\n')
             self._temp_file.write(f'  "document_count": {self._document_count}\n')
             self._temp_file.write("}\n")
             self._temp_file.close()

--- a/src/docpull/pipeline/steps/save_ndjson.py
+++ b/src/docpull/pipeline/steps/save_ndjson.py
@@ -8,15 +8,15 @@ also be written to stdout (``path="-"``) for direct piping into other tools.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
 import sys
 from pathlib import Path
 from typing import IO
 
+from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent
-from ...time_utils import utc_now_iso
+from ...models.run import RunIdentity
 from ..base import EventEmitter, PageContext
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ class NdjsonSaveStep:
         base_output_dir: Path,
         filename: str = "documents.ndjson",
         emit_chunks: bool = False,
+        run_identity: RunIdentity | None = None,
     ) -> None:
         self._base_dir = base_output_dir.resolve()
         self._filename = filename
@@ -45,6 +46,7 @@ class NdjsonSaveStep:
         self._chunk_count = 0
         self._output_path: Path | None = None
         self._lock = asyncio.Lock()
+        self._run_identity = run_identity
 
     def _ensure_open(self) -> IO[str]:
         if self._fp is not None:
@@ -59,6 +61,8 @@ class NdjsonSaveStep:
         return self._fp
 
     def _write_record(self, record: dict[str, object]) -> None:
+        if "content_hash" in record and "hash" not in record:
+            record["hash"] = record["content_hash"]
         fp = self._ensure_open()
         fp.write(json.dumps(record, ensure_ascii=False))
         fp.write("\n")
@@ -72,32 +76,37 @@ class NdjsonSaveStep:
         if ctx.should_skip or ctx.error or not ctx.markdown:
             return ctx
 
-        base_record: dict[str, object] = {
-            "url": ctx.url,
-            "title": ctx.title,
-            "source_type": ctx.source_type,
-            "metadata": ctx.metadata,
-            "fetched_at": utc_now_iso(),
-        }
-
         async with self._lock:
             if self._emit_chunks and ctx.chunks:
                 for chunk in ctx.chunks:
-                    record = dict(base_record)
-                    record["chunk_index"] = getattr(chunk, "index", 0)
-                    record["chunk_heading"] = getattr(chunk, "heading", None)
-                    record["token_count"] = getattr(chunk, "token_count", None)
                     text = getattr(chunk, "text", "")
-                    record["content"] = text
-                    record["hash"] = hashlib.sha256(text.encode("utf-8")).hexdigest()
-                    self._write_record(record)
+                    record = DocumentRecord.from_page(
+                        url=ctx.url,
+                        title=ctx.title,
+                        content=text,
+                        metadata=ctx.metadata,
+                        extraction=ctx.extraction_info,
+                        source_type=ctx.source_type,
+                        run_identity=self._run_identity,
+                        chunk_index=getattr(chunk, "index", 0),
+                        chunk_heading=getattr(chunk, "heading", None),
+                        token_count=getattr(chunk, "token_count", None),
+                    )
+                    self._write_record(record.model_dump(mode="json", exclude_none=True))
                     self._chunk_count += 1
             else:
-                record = dict(base_record)
-                record["content"] = ctx.markdown
-                record["hash"] = hashlib.sha256(ctx.markdown.encode("utf-8")).hexdigest()
-                self._write_record(record)
+                record = DocumentRecord.from_page(
+                    url=ctx.url,
+                    title=ctx.title,
+                    content=ctx.markdown,
+                    metadata=ctx.metadata,
+                    extraction=ctx.extraction_info,
+                    source_type=ctx.source_type,
+                    run_identity=self._run_identity,
+                )
+                self._write_record(record.model_dump(mode="json", exclude_none=True))
             self._document_count += 1
+            ctx.persisted_path = self._output_path
 
         if emit:
             emit(

--- a/src/docpull/pipeline/steps/save_sqlite.py
+++ b/src/docpull/pipeline/steps/save_sqlite.py
@@ -7,8 +7,9 @@ import logging
 import sqlite3
 from pathlib import Path
 
+from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent
-from ...time_utils import utc_now_iso
+from ...models.run import RunIdentity
 from ..base import EventEmitter, PageContext
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ class SqliteSaveStep:
         self,
         base_output_dir: Path,
         filename: str = "documents.db",
+        run_identity: RunIdentity | None = None,
     ) -> None:
         """
         Initialize the SQLite save step.
@@ -54,6 +56,7 @@ class SqliteSaveStep:
         self._conn: sqlite3.Connection | None = None
         self._document_count = 0
         self._pending_count = 0  # Track uncommitted documents
+        self._run_identity = run_identity
 
     def _ensure_db(self) -> sqlite3.Connection:
         """Ensure the database and table exist."""
@@ -65,19 +68,52 @@ class SqliteSaveStep:
             self._conn.execute("""
                 CREATE TABLE IF NOT EXISTS documents (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    schema_version INTEGER NOT NULL DEFAULT 1,
                     url TEXT UNIQUE NOT NULL,
                     title TEXT,
                     content TEXT,
+                    content_hash TEXT,
+                    source_type TEXT,
                     metadata TEXT,
+                    extraction TEXT,
                     fetched_at TEXT
                 )
             """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS run_metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+            """)
+            self._ensure_columns(
+                self._conn,
+                "documents",
+                {
+                    "schema_version": "INTEGER NOT NULL DEFAULT 1",
+                    "content_hash": "TEXT",
+                    "source_type": "TEXT",
+                    "extraction": "TEXT",
+                },
+            )
+            if self._run_identity:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO run_metadata (key, value) VALUES (?, ?)",
+                    ("run", json.dumps(self._run_identity.model_dump(mode="json"), ensure_ascii=False)),
+                )
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_url ON documents(url)")
             self._conn.commit()
 
             logger.info(f"Initialized SQLite database at {self._db_path}")
 
         return self._conn
+
+    @staticmethod
+    def _ensure_columns(conn: sqlite3.Connection, table: str, columns: dict[str, str]) -> None:
+        """Add schema-v1 columns when opening a DB created by older docpull."""
+        existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        for name, definition in columns.items():
+            if name not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
 
     async def execute(
         self,
@@ -98,18 +134,32 @@ class SqliteSaveStep:
             return ctx
 
         conn = self._ensure_db()
+        record = DocumentRecord.from_page(
+            url=ctx.url,
+            title=ctx.title,
+            content=ctx.markdown,
+            metadata=ctx.metadata,
+            extraction=ctx.extraction_info,
+            source_type=ctx.source_type,
+            run_identity=self._run_identity,
+        )
 
         try:
             cursor = conn.execute(
                 """INSERT OR IGNORE INTO documents
-                   (url, title, content, metadata, fetched_at)
-                   VALUES (?, ?, ?, ?, ?)""",
+                   (schema_version, url, title, content, content_hash,
+                    source_type, metadata, extraction, fetched_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
-                    ctx.url,
-                    ctx.title,
-                    ctx.markdown,
-                    json.dumps(ctx.metadata, ensure_ascii=False),
-                    utc_now_iso(),
+                    record.schema_version,
+                    record.url,
+                    record.title,
+                    record.content,
+                    record.content_hash,
+                    record.source_type,
+                    json.dumps(record.metadata, ensure_ascii=False),
+                    json.dumps(record.extraction, ensure_ascii=False),
+                    record.fetched_at,
                 ),
             )
             # Only count if a row was actually inserted (not ignored)
@@ -130,10 +180,11 @@ class SqliteSaveStep:
                         message=f"Saved to SQLite ({self._document_count} docs)",
                     )
                 )
+            ctx.persisted_path = self._db_path
 
         except sqlite3.Error as e:
             logger.error(f"SQLite error saving {ctx.url}: {e}")
-            ctx.error = f"SQLite error: {e}"
+            ctx.mark_failed(f"SQLite error: {e}")
 
             if emit:
                 emit(

--- a/src/docpull/pipeline/steps/validate.py
+++ b/src/docpull/pipeline/steps/validate.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ...models.events import EventType, FetchEvent
+from ...models.events import EventType, FetchEvent, SkipReason
 from ...security.robots import RobotsChecker
 from ...security.url_validator import UrlValidator
 from ..base import EventEmitter, PageContext
@@ -76,8 +76,10 @@ class ValidateStep:
         # 1. URL security validation
         validation_result = self._url_validator.validate(url)
         if not validation_result.is_valid:
-            ctx.should_skip = True
-            ctx.skip_reason = f"URL validation failed: {validation_result.rejection_reason}"
+            ctx.mark_skipped(
+                f"URL validation failed: {validation_result.rejection_reason}",
+                SkipReason.URL_VALIDATION_FAILED,
+            )
             logger.debug(f"Skipping {url}: {validation_result.rejection_reason}")
 
             if emit:
@@ -86,14 +88,14 @@ class ValidateStep:
                         type=EventType.FETCH_SKIPPED,
                         url=url,
                         message=f"URL validation failed: {validation_result.rejection_reason}",
+                        skip_reason=SkipReason.URL_VALIDATION_FAILED,
                     )
                 )
             return ctx
 
         # 2. robots.txt compliance
         if not self._robots_checker.is_allowed(url):
-            ctx.should_skip = True
-            ctx.skip_reason = "Blocked by robots.txt"
+            ctx.mark_skipped("Blocked by robots.txt", SkipReason.ROBOTS_DISALLOWED)
             logger.debug(f"Skipping {url}: blocked by robots.txt")
 
             if emit:
@@ -102,14 +104,14 @@ class ValidateStep:
                         type=EventType.FETCH_SKIPPED,
                         url=url,
                         message="Blocked by robots.txt",
+                        skip_reason=SkipReason.ROBOTS_DISALLOWED,
                     )
                 )
             return ctx
 
         # 3. Check if output file already exists
         if self._check_existing and ctx.output_path.exists():
-            ctx.should_skip = True
-            ctx.skip_reason = "Output file already exists"
+            ctx.mark_skipped("Output file already exists", SkipReason.FILE_EXISTS)
             logger.debug(f"Skipping {url}: output file exists at {ctx.output_path}")
 
             if emit:
@@ -119,6 +121,7 @@ class ValidateStep:
                         url=url,
                         output_path=ctx.output_path,
                         message="Output file already exists",
+                        skip_reason=SkipReason.FILE_EXISTS,
                     )
                 )
             return ctx

--- a/tests/test_frontier_resume.py
+++ b/tests/test_frontier_resume.py
@@ -1,0 +1,35 @@
+"""Regression tests for durable crawl frontier state."""
+
+from __future__ import annotations
+
+from docpull.cache.frontier import FrontierState, FrontierStore
+
+
+def test_frontier_persists_terminal_state_immediately(tmp_path):
+    path = tmp_path / "frontier.json"
+    fingerprint = {"schema_version": 1, "start_url": "https://example.com"}
+    store = FrontierStore(path)
+    store.initialize(start_url="https://example.com", run_fingerprint=fingerprint)
+    store.add_many(["https://example.com/a", "https://example.com/b"], source="discovery")
+    store.save()
+
+    store.mark_processing("https://example.com/a")
+    store.mark_succeeded("https://example.com/a")
+
+    reloaded = FrontierStore(path)
+    assert reloaded.compatible(start_url="https://example.com", run_fingerprint=fingerprint)
+    assert reloaded.entries["https://example.com/a"].state == FrontierState.SUCCEEDED
+    assert reloaded.pending_urls() == ["https://example.com/b"]
+
+
+def test_frontier_reinitializes_on_fingerprint_change(tmp_path):
+    path = tmp_path / "frontier.json"
+    store = FrontierStore(path)
+    store.initialize(start_url="https://example.com", run_fingerprint={"max_pages": 1})
+    store.add("https://example.com/a")
+    store.save()
+
+    store.initialize(start_url="https://example.com", run_fingerprint={"max_pages": 2})
+
+    assert store.entries == {}
+    assert store.compatible(start_url="https://example.com", run_fingerprint={"max_pages": 2})

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -423,6 +423,7 @@ def test_partial_meta_treats_cache_as_stale(tmp_path):
     meta.write_text(
         json.dumps(
             {
+                "schema_version": 1,
                 "fetched_at_epoch": time.time(),
                 "page_count": 5,
                 "partial": True,
@@ -449,7 +450,7 @@ def test_atomic_meta_write_no_tmp_left_behind(tmp_path):
     from docpull.mcp.tools import _write_meta
 
     meta = tmp_path / ".x.meta.json"
-    _write_meta(meta, "x", "https://x.test", 3)
+    _write_meta(meta, "x", "https://x.test", 3, profile="rag", max_pages=100)
     assert meta.exists()
     assert not (tmp_path / ".x.meta.json.tmp").exists()
 

--- a/tests/test_save_ndjson.py
+++ b/tests/test_save_ndjson.py
@@ -32,6 +32,8 @@ async def test_ndjson_writes_one_line_per_page(tmp_path):
     records = [json.loads(line) for line in lines]
     assert [r["url"] for r in records] == [f"https://example.com/p{i}" for i in range(3)]
     assert all("hash" in r for r in records)
+    assert all(r["schema_version"] == 1 for r in records)
+    assert all("content_hash" in r for r in records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_save_sqlite.py
+++ b/tests/test_save_sqlite.py
@@ -1,0 +1,52 @@
+"""Tests for SQLite output schema compatibility."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from docpull.pipeline.base import PageContext
+from docpull.pipeline.steps.save_sqlite import SqliteSaveStep
+
+
+@pytest.mark.asyncio
+async def test_sqlite_save_migrates_legacy_documents_table(tmp_path):
+    db_path = tmp_path / "documents.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            url TEXT UNIQUE NOT NULL,
+            title TEXT,
+            content TEXT,
+            metadata TEXT,
+            fetched_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    step = SqliteSaveStep(tmp_path)
+    ctx = PageContext(
+        url="https://example.com/page",
+        output_path=tmp_path / "page.md",
+        markdown="# Page\n\nBody",
+        title="Page",
+    )
+
+    await step.execute(ctx)
+    step.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(documents)")}
+        assert {"schema_version", "content_hash", "source_type", "extraction"} <= columns
+        row = conn.execute("SELECT url, schema_version, content_hash FROM documents").fetchone()
+        assert row[0] == "https://example.com/page"
+        assert row[1] == 1
+        assert row[2]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- add durable crawl frontier state and run fingerprints for resume compatibility
- add schema-versioned document records across JSON, NDJSON, SQLite, MCP metadata, and progress events
- harden cache state/manifest loading and add regression tests for frontier resume and SQLite migration

## Verification
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy src
- git diff --check