### PR TITLE
Add release accuracy audit fixes

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "docpull",
+  "version": "4.0.0",
+  "description": "Pull server-rendered web content from any URL into Claude Code. Indexes sites in seconds with conditional-GET caching, then exposes them as MCP tools (fetch_url, ensure_docs, list_sources, list_indexed, grep_docs, read_doc, add_source, remove_source). Local, browser-free, no API keys.",
+  "author": {
+    "name": "Raintree Technology",
+    "email": "support@raintree.technology",
+    "url": "https://github.com/raintree-technology/docpull"
+  },
+  "homepage": "https://github.com/raintree-technology/docpull",
+  "repository": "https://github.com/raintree-technology/docpull",
+  "license": "MIT",
+  "keywords": [
+    "web",
+    "crawler",
+    "fetch",
+    "markdown",
+    "rag",
+    "mcp",
+    "local-first"
+  ]
+}

--- a/.claude-plugin/plugin/.codex-plugin/plugin.json
+++ b/.claude-plugin/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "docpull",
+  "version": "4.0.0",
+  "description": "Pull server-rendered web content from any URL into Codex through docpull's local MCP server.",
+  "skills": "./skills/"
+}

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "docpull": {
+      "command": "docpull",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.claude-plugin/plugin/README.md
+++ b/.claude-plugin/plugin/README.md
@@ -1,0 +1,142 @@
+# docpull plugin for Claude Code
+
+Pull server-rendered web content from any URL into Claude Code. Local, fast, no API keys.
+
+This package is the agent wrapper around docpull's local MCP server. Claude Code
+can install it as a Claude plugin; Codex can package the same `skills/` folder
+through `.codex-plugin/plugin.json`. Cursor and Claude Desktop connect
+`docpull mcp` directly.
+
+This repo also carries host-native project guidance for the direct-MCP paths:
+Claude Code can read `.mcp.json` plus `CLAUDE.md`; Cursor reads
+`.cursor/mcp.json` plus `.cursor/rules/docpull-research.mdc`; Codex reads
+`AGENTS.md`, supports project `.codex/config.toml` in trusted repos, and can
+discover repo skills from `.agents/skills`.
+
+## What you get
+
+- **MCP server** (8 tools):
+  - Read: `fetch_url`, `list_sources`, `list_indexed`, `grep_docs`, `read_doc`
+  - Write: `ensure_docs`, `add_source`, `remove_source`
+  - All read tools advertise `readOnlyHint` so hosts that auto-approve safe tools won't prompt for them.
+- **MCP prompts**:
+  - `/mcp__docpull__docs_add <alias-or-url>` — fetch a built-in alias, or register an HTTPS docs URL and then fetch it into the local index.
+  - `/mcp__docpull__docs_search <pattern> [library]` — regex-search cached docs and pull surrounding context for the top hits.
+  - `/mcp__docpull__docs_list` — show what's cached, with last-fetched age.
+  - `/mcp__docpull__docs_refresh <library>` — bypass the 7-day cache and re-fetch.
+  - `/mcp__docpull__docs_remove <library> [--keep-cache]` — drop a user alias and its cached docs.
+- **Meta-skill** (`docpull-research`): teaches Claude *when* to reach for docpull — so you don't have to remember the tool exists every time you ask about a library or web source.
+
+## Prerequisite
+
+The plugin wraps the `docpull` CLI; install it with the `[mcp]` extra so the
+MCP server is available:
+
+```bash
+pip install 'docpull[mcp]'          # or: pipx install 'docpull[mcp]'
+                                    #     uv tool install 'docpull[mcp]'
+docpull --version                   # should print 4.0.0 or newer
+docpull mcp --help                  # confirm the MCP subcommand is wired
+```
+
+The plain `pip install docpull` works for CLI use but does **not** include the
+`mcp` Python package — `docpull mcp` will exit with "requires the 'mcp'
+package". Always install with `[mcp]` for plugin use.
+
+## Install
+
+In Claude Code:
+
+```
+/plugin marketplace add raintree-technology/docpull
+/plugin install docpull@docpull
+```
+
+The MCP server starts automatically. The skill activates when you ask Claude about a specific library.
+
+In Codex, the same folder is a Codex plugin source via
+`plugin/.codex-plugin/plugin.json`. For direct MCP setup, use:
+
+```bash
+codex mcp add docpull -- docpull mcp
+```
+
+Or, in a trusted repo, add this to `.codex/config.toml`:
+
+```toml
+[mcp_servers.docpull]
+command = "docpull"
+args = ["mcp"]
+```
+
+From this repo, regenerate Codex's project config, repo-scoped skill copy, and
+local plugin marketplace with:
+
+```bash
+make sync-agent-host-configs
+```
+
+For local bundle installs or smoke tests, first generate the self-contained
+bundle:
+
+```bash
+python scripts/sync_claude_plugin.py
+```
+
+Then point Claude Code at `.claude-plugin/`. The bundle is generated from
+`plugin/`; the copied plugin payload is not checked into git.
+
+## 60-second demo
+
+```
+> /mcp__docpull__docs_add fastapi
+[fetches the FastAPI docs in ~15s; ~400 pages, full-text indexed locally]
+
+> How does FastAPI handle dependency injection scoping?
+[Claude reaches for grep_docs(library="fastapi", pattern="depend"), pulls the
+ relevant section, and answers with attribution to the actual docs file]
+```
+
+Older `/docs-add` plugin command wrappers are intentionally not shipped; the
+workflows now live with the MCP server so they work through any host that
+supports MCP prompts.
+
+## Built-in library aliases
+
+These are fetchable by name without any URL setup: `react`, `nextjs`, `tailwindcss`, `vite`, `hono`, `fastapi`, `express`, `anthropic`, `openai`, `langchain`, `supabase`, `drizzle`, `prisma`.
+
+For anything else, pass an HTTPS URL to the prompt. It derives an alias, writes
+that alias to `~/.config/docpull-mcp/sources.yaml`, then calls `ensure_docs`:
+
+`/mcp__docpull__docs_add https://docs.your-library.com`.
+
+## Where docs are cached
+
+By default, fetched docs live under `$XDG_DATA_HOME/docpull-mcp/docs/` (or
+`~/.local/share/docpull-mcp/docs/` on macOS/Linux). Override with
+`DOCPULL_DOCS_DIR` if you want them somewhere else (e.g. one cache per
+project).
+
+## Privacy
+
+- 100% local. No telemetry. No remote services.
+- The plugin only sends HTTP requests to the URLs you ask it to fetch.
+- The User-Agent is `docpull/<version> (+https://github.com/raintree-technology/docpull)` — public, identifiable, robots.txt-respecting.
+
+## Troubleshooting
+
+| Symptom                                     | Fix |
+|---------------------------------------------|-----|
+| MCP tools missing after install             | Run `docpull mcp --help`. If it errors with "requires the 'mcp' package", reinstall with `pip install 'docpull[mcp]'`. |
+| `/mcp__docpull__docs_add fastapi` says "unknown source" | Run `mcp__docpull__list_sources()` to see current aliases. If the source is not listed, use `/mcp__docpull__docs_add <name> <https-url>` to register it. |
+| Slow first fetch                            | Normal — first crawl populates the cache. Subsequent runs hit the conditional-GET cache (~70 ms time-to-first-result). |
+| Want to refresh stale docs                  | `mcp__docpull__ensure_docs(source="<alias>", force=true)`. |
+
+## Notes
+
+Direct MCP tools and MCP prompts are the supported workflow. Legacy plugin
+command wrappers such as `/docs-add` are intentionally not shipped.
+
+## License
+
+MIT — same as docpull itself. Source: <https://github.com/raintree-technology/docpull>.

--- a/.claude-plugin/plugin/skills/docpull-research/SKILL.md
+++ b/.claude-plugin/plugin/skills/docpull-research/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: docpull-research
+description: Use the docpull MCP tools (list_indexed, list_sources, ensure_docs, grep_docs, read_doc, fetch_url) to ground answers in real documentation when the user asks about a specific library, framework, SDK, API surface, version-sensitive tool behavior, or pasted documentation URL. Especially useful for fast-moving libraries and tool ecosystems such as Next.js, FastAPI, LangChain, React, Tailwind, Drizzle, Prisma, Anthropic/OpenAI SDKs, Vercel AI SDK, and Vercel skills.sh / skills CLI docs.
+allowed-tools: mcp__docpull__list_indexed, mcp__docpull__list_sources, mcp__docpull__ensure_docs, mcp__docpull__grep_docs, mcp__docpull__read_doc, mcp__docpull__fetch_url
+---
+
+# docpull research
+
+Ground library/framework answers in real documentation instead of training-data recall. The cost of one `grep_docs` call is ~50 ms; the cost of giving a confidently wrong answer about a fast-moving API is much higher.
+
+## When to use this skill
+
+**Activate when** the user's question names a specific library, framework, SDK, API surface, or docs-backed tool ecosystem — especially:
+
+- **Fast-moving libraries** where training-data drift is likely: Next.js (App Router), Pydantic v2, LangChain, FastAPI, Anthropic SDK, OpenAI SDK, Drizzle, Prisma, Tailwind v4+, Vercel AI SDK.
+- **Version-specific questions** ("how does X work in [library] v[N]").
+- **Pasted docs URLs** the user wants explained or referenced.
+- **Agent/tooling ecosystems** with live docs or CLIs, including `skills.sh`, `github.com/vercel-labs/skills`, Vercel agent skills, MCP docs, and SDK command references.
+- **Code the user is actively writing** against a library, where wrong signatures will cost them debugging time.
+
+**Do NOT activate for**:
+
+- General programming questions ("what's a closure", "explain async/await").
+- The user's own codebase — that's what Read/Grep are for.
+- Highly stable, well-known stdlib APIs (Python `os`, JavaScript `Array.prototype`).
+- Clarifying questions where the answer is trivial from context.
+
+## Workflow
+
+### 1. Check what's already cached
+
+Always start with `list_indexed`. It's free and tells you which libraries you can search immediately without fetching.
+
+```
+list_indexed() → ["fastapi (3d ago)", "react (12h ago)", ...]
+```
+
+### 2. If the library is cached → search it
+
+Use `grep_docs` with a focused regex. Prefer API nouns, method names, command names, or option flags over whole natural-language questions. The library is already on disk, so this is a local search:
+
+```
+grep_docs(library="fastapi", pattern="dependency injection", limit=10, context=2)
+```
+
+If you want more context around a hit, use `read_doc(library, path, line_start, line_end)`.
+
+### 3. If the source is NOT cached → decide whether to fetch
+
+- **Built-in alias** (the library appears in `list_sources()`): call `ensure_docs(source="<alias>")`. This crawls and indexes the whole library. ~10–30s for typical sites.
+- **Arbitrary URL**: call `fetch_url(url=...)` if you only need one page. For a whole site you don't have an alias for, tell the user to run `/mcp__docpull__docs_add <URL>`; the MCP `fetch_url` is single-page only.
+- **No alias, user didn't paste a URL**: ask the user once whether they'd like to add the library, and what the docs URL is. Don't fetch speculatively.
+
+### 4. Special case: skills.sh and Vercel skills CLI
+
+For questions about Vercel skills, `skills.sh`, `npx skills`, agent skill installation, or `SKILL.md` structure:
+
+- Treat the docs as version-sensitive. First check `list_indexed` for an existing `skills`, `skills.sh`, or `vercel-labs-skills` source.
+- If cached, search for exact commands or flags such as `skills add`, `--agent`, `--skill`, `--copy`, `--yes`, `skills use`, `skills list`, `skills find`, `skills update`, `skills remove`, `SKILL.md`, `frontmatter`, or the named agent.
+- If not cached and the user pasted a skills.sh docs page, use `fetch_url` on that page.
+- If not cached and no URL was pasted, prefer the official docs page `https://www.skills.sh/docs` for a quick one-page answer. For CLI option details, ask once before crawling the full GitHub repo, or use the official README URL if the user only needs install/use command syntax.
+- When giving install commands for this repo, preserve project policy: `npx -y skills add <package> --skill '*' --agent codex --copy --yes`, then remove installer artifacts with `rm -rf .agents skills-lock.json`.
+- Mention the security boundary from skills.sh when relevant: public skills can be audited, but users should review skill contents before installing.
+
+### 5. Quote with attribution
+
+When you cite docs, include the source path returned by `grep_docs` / `read_doc` so the user can verify. Example: "Per `fastapi/tutorial/dependencies.md:42`, dependencies declared with `Depends()` are resolved per-request..."
+
+For one-page `fetch_url` answers, name the page URL or page title in the answer. For cached docs, prefer `library/path.md:line` style references.
+
+### 6. Don't over-fetch
+
+- Don't call `ensure_docs` for libraries the user didn't ask about ("while we're here, let me also fetch...").
+- Don't crawl the same library twice in one session — `list_indexed` will tell you it's there.
+- If `grep_docs` returns nothing useful, broaden the regex once before suggesting the user add more docs.
+
+## Built-in aliases
+
+These are pre-configured and resolvable by `ensure_docs(source=...)` without setup: `react`, `nextjs`, `tailwindcss`, `vite`, `hono`, `fastapi`, `express`, `anthropic`, `openai`, `langchain`, `supabase`, `drizzle`, `prisma`. Run `list_sources()` for the current set.
+
+## Failure modes
+
+- **`ensure_docs` returns "unknown source"**: the alias isn't built-in. Either suggest `/mcp__docpull__docs_add <URL>` or call `list_sources()` and propose a near match.
+- **`grep_docs` returns empty**: the pattern is too narrow, or the library doesn't cover the topic. Broaden once, then surface the gap to the user.
+- **`fetch_url` cannot read a docs page**: state that docpull could not fetch the page, then use a browser/search fallback only if the host permits it and the question needs current docs.
+- **MCP server not responding**: tell the user to run `pip install 'docpull[mcp]'` and verify the plugin's MCP server is healthy. Fall back to answering from training data with an explicit caveat that docs weren't available.
+
+## Tone
+
+When you've grounded an answer in fetched docs, say so once at the start of the answer ("Per the FastAPI docs..."). Don't pad every paragraph with attribution — one source citation up front plus inline file references is enough.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ content directly from framework data feeds:
 | Mintlify  | `__NEXT_DATA__` with Mintlify tagging |
 | OpenAPI   | Renders `openapi.json` / `swagger.json` into Markdown |
 | Docusaurus| Detected and tagged; generic extractor produces Markdown |
-| Sphinx    | Detected and tagged; generic extractor produces Markdown |
+| Sphinx    | Detected from generator metadata / Read the Docs hosts and tagged; generic extractor produces Markdown |
 
 JS-only SPAs with no server-rendered content are detected and skipped with a
 clear reason (or, with `--strict-js-required`, reported as an error so agents
@@ -125,8 +125,8 @@ async def tool_call(url: str) -> str:
 
 ```bash
 docpull https://site.com --profile rag      # Default. Dedup, rich metadata.
-docpull https://site.com --profile llm      # NDJSON + chunks + metadata.
-docpull https://site.com --profile mirror   # Full archive, polite, cached.
+docpull https://site.com --profile llm      # NDJSON + chunks + metadata; JS-only pages skip unless --strict-js-required is passed.
+docpull https://site.com --profile mirror   # Full archive, polite, cached, hierarchical paths.
 docpull https://site.com --profile quick    # Sampling: 50 pages, depth 2.
 ```
 
@@ -195,7 +195,9 @@ Write:
 - `add_source(name, url, description?, category?, max_pages?, force?)` — register a user alias (HTTPS-only, atomic write to `sources.yaml`).
 - `remove_source(name, delete_cache?)` — drop a user alias and (optionally) its cached docs.
 
-All tools that carry data also return `structuredContent` validated against an `outputSchema` for clients that prefer typed output.
+All schema-backed tools return `structuredContent` validated against an
+`outputSchema` for clients that prefer typed output. `fetch_url` intentionally
+returns Markdown text directly.
 
 User-defined sources live in `~/.config/docpull-mcp/sources.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,13 @@ The `mcp/` directory at the repo root is a separate TypeScript + Bun MCP
 server backed by PostgreSQL with pgvector for semantic search. It is not
 the Python MCP server shipped in the `docpull` package described above
 — that one is the right choice for almost every user and is installed
-with `pip install 'docpull[mcp]'`. The `mcp/` tree is mirrored to its
-own repo at [`raintree-technology/docpull-mcp`](https://github.com/raintree-technology/docpull-mcp);
-unless you specifically need pgvector-backed semantic search, ignore it
-and use `docpull mcp`.
+with `pip install 'docpull[mcp]'`.
+
+Treat the root `mcp/` tree as experimental in-tree source for the pgvector
+semantic-search path. It is not part of the Python package release contract,
+and this README does not claim a public mirror is available. Unless you are
+working on that separate semantic-search server, ignore it and use
+`docpull mcp`.
 
 ## Output
 
@@ -237,8 +240,13 @@ source_type: "nextjs"
 NDJSON (one record per page or chunk):
 
 ```json
-{"url": "...", "title": "...", "content": "...", "hash": "...", "token_count": 842, "chunk_index": 0}
+{"document_id": "doc_...", "chunk_id": "chunk_...", "url": "...", "title": "...", "content": "...", "hash": "...", "token_count": 842, "chunk_index": 0}
 ```
+
+Every output format also writes `corpus.manifest.json` next to the generated
+documents. The manifest records the run identity, output format, stable
+`document_id` / `chunk_id` values, content hashes, relative output paths, and
+chunk counts so regenerated corpora can be diffed and cited by agents.
 
 ## Security
 

--- a/audit/00_EXECUTIVE_SUMMARY.md
+++ b/audit/00_EXECUTIVE_SUMMARY.md
@@ -1,0 +1,58 @@
+# Executive Summary
+
+## What DocPull Is
+
+DocPull is a Python CLI/library that fetches static documentation pages over async HTTP, validates URLs against SSRF policy, respects robots.txt, converts content to Markdown/JSON/NDJSON/SQLite-oriented records, and exposes a package-shipped Python stdio MCP server for agent use. The repo also contains a separate Bun/TypeScript `mcp/` server with PostgreSQL/pgvector semantic search and a Claude Code plugin bundle.
+
+Audit target/version evidence:
+- `pyproject.toml:6-7` declares package `docpull` version `4.0.0`.
+- `python -m pip show docpull` in `.venv` reports editable package `Version: 4.0.0`.
+- Git `HEAD` is `a3a288e chore(release): 4.0.0 (#48)`.
+- Current worktree is dirty and currently broken at import time; this is not a clean 4.0.0 runtime.
+
+## What Works
+
+Verified by static evidence and tests present in the repo:
+- Strong URL validation design: HTTPS-only defaults, localhost/internal suffix blocks, private/link-local/reserved/multicast/CGNAT IP blocks, IPv4-mapped IPv6 handling, and single-resolution `resolve_allowed_addresses()` in `src/docpull/security/url_validator.py:48-197`.
+- Connect-time DNS pinning in aiohttp when no proxy is configured via `_ValidatedResolver` in `src/docpull/http/client.py:32-76` and `AsyncHttpClient.__aenter__` in `src/docpull/http/client.py:269-285`.
+- Redirect revalidation and auth stripping across origins in `src/docpull/http/client.py:203-267`.
+- robots.txt fail-closed behavior, redirect handling, pinned HTTPS connection, and 512 KB cap in `src/docpull/security/robots.py:97-203`.
+- Sitemap XML parsing uses `defusedxml` with size/depth limits in `src/docpull/discovery/sitemap.py:9-43` and `149-186`.
+- Python MCP tool surface and schemas are defined for 8 tools with annotations and structured output in `src/docpull/mcp/server.py:225-485`.
+- MCP path traversal and ReDoS mitigations exist in `src/docpull/mcp/tools.py:462-628` and `631-706`.
+
+## What Is Risky
+
+Top confirmed risks/gaps:
+1. **Critical local worktree breakage**: `docpull --version`, `docpull --help`, `docpull --doctor`, tests, and coverage all fail to import because `FetchEvent.progress()` annotates `-> FetchEvent` without postponed annotations in `src/docpull/models/events.py:131-140`.
+2. **Docs/runtime mismatch**: README says LLM profile is agent/LLM-ready and the profile comment says fail-loud on JS-only pages, but `ProfileName.LLM` sets `strict_js_required=False` in `src/docpull/models/profiles.py:47-64`.
+3. **CLI/config mismatch**: CLI accepts `--naming-strategy flat|short` in `src/docpull/cli.py:136-143`, while `OutputConfig.naming_strategy` only accepts `full|hierarchical` in `src/docpull/models/config.py:145-150`.
+4. **Plugin cache path mismatch**: plugin README claims `$XDG_DATA_HOME/docpull/docs` / `~/.local/share/docpull/docs`, but Python MCP defaults to `$XDG_DATA_HOME/docpull-mcp/docs` / `~/.local/share/docpull-mcp/docs` in `src/docpull/mcp/sources.py:114-120`.
+5. **README mirror claim unverified**: README claims root `mcp/` is mirrored to `raintree-technology/docpull-mcp` in `README.md:211-219`; browser/search evidence did not verify a public mirror.
+6. **Current audit could not run functional crawl tests** because import failure blocks runtime validation.
+7. **pip install and pip-audit were blocked by DNS/network restrictions**, so dependency vulnerability verification is incomplete.
+8. **Proxy mode weakens DNS-pinning guarantees by design**; `--require-pinned-dns` exists, but default proxy behavior still relies on users/agents understanding the warning.
+9. **Root TypeScript MCP is duplicated product surface** with different tools, versioning, cache metadata, and deployment assumptions than Python MCP.
+10. **Performance claims are only partially verified**: benchmark test code exists, but current worktree cannot collect tests.
+
+## Top 10 Improvements
+
+1. Fix the current import blocker and make `ruff`, `mypy`, `pytest`, and CLI smoke tests green before any expansion.
+2. Align LLM profile docs/comment/behavior: either set `strict_js_required=True` or remove fail-loud wording.
+3. Remove deprecated `flat`/`short` from CLI choices or map them before Pydantic validation with explicit deprecation messaging.
+4. Fix plugin README cache path and version prerequisite (`2.5.0 or newer` should be `4.0.0 or newer` if current plugin targets v4).
+5. Decide root `mcp/` strategy: split to public repo, mark experimental/private, or fold roadmap into Python MCP.
+6. Add a clean-release CI gate that imports `docpull`, runs `docpull --version`, `--help`, `--doctor`, and `docpull mcp --help`.
+7. Add end-to-end localhost fixtures for every advertised output format and profile.
+8. Add security regression tests for proxy warning/`--require-pinned-dns`, decompression bombs, symlink cache/output attacks, and source registry poisoning.
+9. Add docs architecture/security model pages so users understand browser-free constraints and trust boundaries.
+10. Prioritize agent-native output work: stable chunk IDs, manifest schema, citation/source maps, and optional SQLite FTS.
+
+## 30/60/90 Day Recommendation
+
+30 days: stabilize correctness/security/docs. Fix current runtime breakage, resolve claim gaps, publish a patch, and add CLI/MCP smoke tests that would have caught the import failure.
+
+60 days: productize agent workflows. Harden plugin docs, add per-project caches, `/docs-skill`, stable chunk IDs, manifest schema, and a verified cookbook against small fixture docs sites.
+
+90 days: strategic expansion. Add optional JS rendering adapter, authenticated/internal docs model, semantic search path, SQLite FTS, and framework extractors for MkDocs, VitePress, Starlight, GitBook, ReadMe.io, and Redoc/Scalar variants.
+

--- a/audit/00_EXECUTIVE_SUMMARY.md
+++ b/audit/00_EXECUTIVE_SUMMARY.md
@@ -55,4 +55,3 @@ Top confirmed risks/gaps:
 60 days: productize agent workflows. Harden plugin docs, add per-project caches, `/docs-skill`, stable chunk IDs, manifest schema, and a verified cookbook against small fixture docs sites.
 
 90 days: strategic expansion. Add optional JS rendering adapter, authenticated/internal docs model, semantic search path, SQLite FTS, and framework extractors for MkDocs, VitePress, Starlight, GitBook, ReadMe.io, and Redoc/Scalar variants.
-

--- a/audit/01_CONTEXT.md
+++ b/audit/01_CONTEXT.md
@@ -88,4 +88,3 @@ CLI/Python API/MCP
       -> SaveStep / JsonSaveStep / NdjsonSaveStep / SqliteSaveStep
     -> CacheManager / StreamingDeduplicator
 ```
-

--- a/audit/01_CONTEXT.md
+++ b/audit/01_CONTEXT.md
@@ -1,0 +1,91 @@
+# Context
+
+## Repo Map
+
+- `src/docpull/`: shipped Python package.
+- `tests/`: Python unit, integration, MCP, security, and benchmark tests.
+- `docs/`: changelog and YAML example configs.
+- `plugin/`: Claude Code plugin metadata, commands, and `docpull-research` skill.
+- `.claude-plugin/plugin/`: untracked generated plugin bundle in current worktree.
+- `mcp/`: separate Bun/TypeScript MCP server with PostgreSQL/pgvector semantic search.
+- `web/`: Next.js product site.
+- `.github/`: CI, security, publish, benchmark, metrics, templates, security policy.
+
+## Python Package Architecture
+
+- CLI: `src/docpull/cli.py` builds argparse options and maps them into `DocpullConfig`.
+- Config/models: `src/docpull/models/config.py`, `profiles.py`, `events.py`, `run.py`, `document.py`.
+- Core orchestrator: `src/docpull/core/fetcher.py`.
+- HTTP: `src/docpull/http/client.py`, `rate_limiter.py`.
+- Security: `src/docpull/security/url_validator.py`, `robots.py`.
+- Discovery: `src/docpull/discovery/sitemap.py`, `crawler.py`, `filters.py`, `link_extractors/`.
+- Conversion: `src/docpull/conversion/extractor.py`, `markdown.py`, `special_cases.py`, `trafilatura_extractor.py`, `chunking.py`.
+- Pipeline: `src/docpull/pipeline/base.py` plus `steps/validate.py`, `fetch.py`, `convert.py`, `metadata.py`, `dedup.py`, `chunk.py`, `save.py`, `save_json.py`, `save_ndjson.py`, `save_sqlite.py`.
+- Cache/resume: `src/docpull/cache/manager.py`, `streaming_dedup.py`, dirty-worktree `frontier.py`.
+- Python MCP: `src/docpull/mcp/server.py`, `tools.py`, `sources.py`.
+
+## Runtime Data Flow
+
+1. CLI parses args in `src/docpull/cli.py:48-369`.
+2. CLI maps args to `DocpullConfig` in `src/docpull/cli.py:372-528`.
+3. `Fetcher` applies profile defaults in `src/docpull/core/fetcher.py:167-176`.
+4. `Fetcher.__aenter__` builds validator, robots checker, HTTP client, discoverers, cache, and pipeline.
+5. Discovery uses sitemaps plus link crawling: `SitemapDiscoverer` and `LinkCrawler`.
+6. Each URL enters `FetchPipeline.execute_result()` in `src/docpull/pipeline/base.py:181-222`.
+7. Pipeline validates URL/robots/cache, fetches bytes, converts/special-cases, extracts metadata, deduplicates/chunks, and saves.
+8. Output writers persist Markdown, JSON, NDJSON, or SQLite records.
+9. `Fetcher.run()` emits `FetchEvent` records for CLI/MCP/progress consumers.
+
+## Trust Boundaries
+
+- User/agent-controlled URL enters CLI, Python API, or MCP `fetch_url`/`add_source`.
+- DNS resolver is adversarial for SSRF/DNS-rebinding assumptions.
+- Remote HTML/XML/JSON/YAML-ish metadata is untrusted.
+- robots.txt and sitemap XML are untrusted network input.
+- Output/cache directories are local filesystem trust boundaries; symlinks and traversal matter.
+- MCP exposes local cached Markdown to AI hosts; library/path validation matters.
+- Auth headers/cookies are secrets and must not cross origins or leak in logs/errors.
+- Root `mcp/` adds database and OpenAI API boundaries.
+
+## Extension Seams
+
+- Add URL policy rules in `UrlValidator`.
+- Add discovery sources via `Discoverer` protocol and `CompositeDiscoverer`.
+- Add framework extraction via `SpecialCaseExtractor` chain in `conversion/special_cases.py`.
+- Add output formats as pipeline save steps.
+- Add MCP tools in `src/docpull/mcp/server.py` and implementations in `tools.py`.
+- Add Claude Code UX in `plugin/commands` and `plugin/skills`.
+- Add semantic/FTS storage in SQLite or root `mcp/` DB layer.
+
+## Duplicated/Dead Systems
+
+- Python MCP and root TypeScript MCP are separate products with different capabilities and operational models.
+- Root `mcp/package.json:2-3` says `docpull-mcp` version `0.3.0`, while `mcp/src/server.ts:396` initializes server version `0.2.0`.
+- README points to a root `mcp/` mirror that appears unverified/publicly unavailable.
+- Current dirty worktree introduces `src/docpull/cache/frontier.py`, `models/document.py`, `models/run.py`, SQLite/frontier tests, and pipeline changes, but the import failure prevents validating them.
+
+## Dependency Graph
+
+```text
+CLI/Python API/MCP
+  -> DocpullConfig + profiles
+  -> Fetcher
+    -> UrlValidator + RobotsChecker
+    -> AsyncHttpClient + rate limiters
+    -> CompositeDiscoverer
+      -> SitemapDiscoverer
+      -> LinkCrawler + link extractors
+    -> FetchPipeline
+      -> ValidateStep
+      -> FetchStep
+      -> ConvertStep
+        -> special-case extractors
+        -> MainContentExtractor
+        -> HtmlToMarkdown + FrontmatterBuilder
+      -> MetadataStep
+      -> DedupStep
+      -> ChunkStep
+      -> SaveStep / JsonSaveStep / NdjsonSaveStep / SqliteSaveStep
+    -> CacheManager / StreamingDeduplicator
+```
+

--- a/audit/02_FUNCTIONALITY_MATRIX.md
+++ b/audit/02_FUNCTIONALITY_MATRIX.md
@@ -32,4 +32,3 @@
 | Claude plugin slash commands | Yes | Yes | Partial | Static | `plugin/README.md:7-18`, `plugin/commands/*` | Cache path docs wrong | P0 |
 | Root TypeScript MCP mirror | Yes | Yes in-tree | Some TS tests | Unverified public mirror | `README.md:211-219`, `mcp/package.json:1-19` | Public repo unavailable/unverified | P1 |
 | Performance 10k benchmark | Yes | Yes | Yes | Not run | `.github/workflows/benchmark.yml`, `tests/benchmarks/test_10k_pages.py` | Import failure prevents local run | P0 |
-

--- a/audit/02_FUNCTIONALITY_MATRIX.md
+++ b/audit/02_FUNCTIONALITY_MATRIX.md
@@ -1,0 +1,35 @@
+# Functionality Matrix
+
+| Feature | Documented? | Implemented? | Tested? | Verified by audit? | Evidence | Gaps | Priority |
+|---|---:|---:|---:|---:|---|---|---|
+| Package version 4.0.0 | Yes | Yes | Partial | Yes | `pyproject.toml:6-7`, `pip show docpull` | Runtime CLI blocked in dirty worktree | P0 |
+| CLI `--version` | Yes | Yes | Yes | Broken in worktree | `cli.py:76-80`; command fails importing `FetchEvent` | Fix import blocker | P0 |
+| CLI `--help` | Yes | Yes | Partial | Broken in worktree | `cli.py:48-369`; command fails importing `FetchEvent` | Add no-import-regression smoke | P0 |
+| CLI `--doctor` | Yes | Yes | Unknown | Broken in worktree | `cli.py:10-20`, `doctor.py`; command fails before doctor path through script import | Make doctor import-light | P0 |
+| `--single` | Yes | Yes | Partial | Static only | `README.md:44-45`, `cli.py:97-101`, `cli.py:547-565` | Runtime blocked | P0 |
+| Profiles `rag/mirror/quick/llm` | Yes | Yes | Yes | Partial | `README.md:124-131`, `profiles.py:9-69` | LLM fail-loud claim mismatch | P0 |
+| Markdown output | Yes | Yes | Yes | Static only | `OutputConfig.format` in `config.py:140-144`, `SaveStep` | Runtime blocked | P0 |
+| JSON output | Yes | Yes | Yes | Static only | `cli.py:129-134`, `JsonSaveStep` present | Schema docs thin | P1 |
+| NDJSON/stream output | Yes | Yes | Yes | Static only | `README.md:237-241`, `save_ndjson.py:25-69` | Runtime blocked | P0 |
+| SQLite output | Yes | Yes | New tests | Static only | `config.py:141`, `save_sqlite.py`, `test_save_sqlite.py` | Worktree changes blocked; docs minimal | P0 |
+| Cache/incremental | Yes | Yes | Yes | Static only | `cli.py:312-342`, `FetchStep` conditional headers | Runtime blocked | P0 |
+| Resume/frontier | Site/docs claim | Worktree partial | New tests | Broken/unverified | `web/components/Features.tsx:18-20`, dirty `frontier.py` | Import failure blocks; public HEAD may not include frontier | P0 |
+| SSRF controls | Yes | Yes | Yes | Static + tests present | `url_validator.py:48-197`, `test_security_hardening.py` | Need decompression/proxy edge tests | P1 |
+| DNS pinning | Yes | Yes | Yes | Static | `http/client.py:32-76`, `robots.py:47-76` | Proxy mode weaker by design | P1 |
+| robots.txt mandatory | Yes | Yes | Yes | Static | `validate.py:96-107`, `robots.py:193-203` | Crawl-delay not clearly enforced from robots | P1 |
+| Sitemap discovery | Yes | Yes | Yes | Static | `sitemap.py:23-43`, tests in `test_discovery.py` | Size checked after response already in memory | P1 |
+| Link crawling | Yes | Yes | Yes | Static | `crawler.py:25-42`, `143-229` | Need canonical URL behavior docs/tests | P2 |
+| Next.js extraction | Yes | Yes | Yes | Static | `README.md:59-65`, `special_cases.py:85-171` | App Router coverage partial | P2 |
+| Mintlify extraction | Yes | Yes | Yes | Static | `special_cases.py:193-214` | Delegates to Next only | P2 |
+| Docusaurus/Sphinx | Yes | Partial | Partial | Partial | Docusaurus detector returns `None` intentionally at `special_cases.py:174-190`; README says tagged/generic | Sphinx implementation not evident in inspected snippet; claim needs direct test/code trace | P1 |
+| OpenAPI extraction | Yes | Yes | Yes | Static | `special_cases.py:306-360` | Needs Redoc/Scalar variants | P2 |
+| JS-only detection | Yes | Yes | Yes | Static | tests `test_spa_detected_and_skipped`, `test_strict_js_required_raises_error` | LLM profile not strict despite comment | P0 |
+| Rich metadata | Yes | Yes | Yes | Static | `metadata_extractor.py:36-92` | Potential extruct parser limits not documented | P1 |
+| YAML frontmatter hardening | Yes | Yes | Yes | Static | `markdown.py:218-277`, changelog `docs/CHANGELOG.md:28-30` | Add fuzz/regression corpus | P1 |
+| Python API `fetch_one` | Yes | Yes | Partial | Broken in worktree | `README.md:83-122`, `__init__.py`, `fetcher.py` | Import failure blocks | P0 |
+| Python MCP 8 tools | Yes | Yes | Yes | Static | `README.md:184-198`, `server.py:225-485`, `test_mcp_server.py` | Runtime blocked | P0 |
+| MCP structuredContent | Yes | Yes | Yes | Static | `server.py:596-599`, schemas in `server.py:54-183` | Errors intentionally no structuredContent | P1 |
+| Claude plugin slash commands | Yes | Yes | Partial | Static | `plugin/README.md:7-18`, `plugin/commands/*` | Cache path docs wrong | P0 |
+| Root TypeScript MCP mirror | Yes | Yes in-tree | Some TS tests | Unverified public mirror | `README.md:211-219`, `mcp/package.json:1-19` | Public repo unavailable/unverified | P1 |
+| Performance 10k benchmark | Yes | Yes | Yes | Not run | `.github/workflows/benchmark.yml`, `tests/benchmarks/test_10k_pages.py` | Import failure prevents local run | P0 |
+

--- a/audit/03_SECURITY_REVIEW.md
+++ b/audit/03_SECURITY_REVIEW.md
@@ -1,0 +1,114 @@
+# Security Review
+
+## Threat Model
+
+DocPull accepts URLs from users and AI agents, fetches remote content, parses HTML/XML/JSON/YAML-like metadata, follows links and redirects, writes local files/cache manifests, and exposes local cached docs through MCP. It may run in developer environments containing cloud credentials, source code, SSH keys, API tokens, and private network access.
+
+Primary attacker capabilities:
+- Provide malicious URL, hostname, DNS behavior, redirects, HTML, robots.txt, sitemap XML, OpenAPI JSON, or metadata.
+- Influence cached validator headers by controlling prior server responses.
+- Hand-edit MCP `sources.yaml` or convince an agent to add malicious sources.
+- Plant symlinks or strange paths in output/cache dirs if local filesystem boundary is weak.
+- Trigger expensive regexes through MCP search.
+
+## Confirmed Mitigations
+
+- HTTPS-only default: `UrlValidator.DEFAULT_ALLOWED_SCHEMES = {"https"}` in `src/docpull/security/url_validator.py:48-50`.
+- Local/private/internal host blocking: `url_validator.py:50-57`, `211-237`.
+- DNS root-dot stripping: `url_validator.py:113-121`.
+- DNS rebinding TOCTOU mitigation: single resolution returned from `resolve_allowed_addresses()` in `url_validator.py:159-197`; aiohttp resolver dials those addresses in `http/client.py:32-76`.
+- Redirect target validation: `http/client.py:203-267`.
+- Sensitive auth header stripping cross-origin: `http/client.py:209-235`.
+- robots.txt pinned HTTPS and fail-closed behavior: `security/robots.py:47-76`, `151-203`.
+- robots.txt 512 KB body cap: `security/robots.py:97-99`.
+- XXE-resistant sitemap parsing: `discovery/sitemap.py:9-10`, `149-166`.
+- YAML frontmatter injection mitigation: `conversion/markdown.py:218-277`.
+- Conditional request header sanitization: `pipeline/steps/fetch.py` contains `_sanitize_validator_header` per grep evidence.
+- MCP library/path traversal controls: `mcp/sources.py:65-72`, `mcp/tools.py:647-665`.
+- MCP ReDoS controls: `mcp/tools.py:45-49`, `485-500`, `537-541`.
+
+## Findings
+
+### SEC-001: Current worktree import failure disables security/runtime verification
+
+- Severity: High
+- Confidence: High
+- Surface: CLI, Python API, Python MCP, tests
+- Evidence: `src/docpull/models/events.py:131-140` annotates `FetchEvent.progress(...)-> FetchEvent` without `from __future__ import annotations`; `docpull --version`, `--help`, `--doctor`, `pytest`, and coverage fail with `NameError: name 'FetchEvent' is not defined`.
+- Reproduction: `./.venv/bin/docpull --version`.
+- Expected: version output.
+- Actual: import traceback before argument parsing.
+- Recommended fix: add postponed annotations or quote return type; add CLI import smoke tests.
+- Tests to add: `test_import_docpull_package`, `test_cli_version_no_network`, `test_mcp_subcommand_help_no_import_failure`.
+
+### SEC-002: Proxy mode weakens DNS pinning unless user opts into `--require-pinned-dns`
+
+- Severity: Medium
+- Confidence: High
+- Surface: CLI/network
+- Evidence: `AsyncHttpClient.__aenter__` logs warning and disables `_ValidatedResolver` when `_proxy is not None` in `src/docpull/http/client.py:269-279`; `require_pinned_dns` rejects proxy mode in `src/docpull/http/client.py:162-168`.
+- Reproduction: configure `--proxy` without `--require-pinned-dns`.
+- Expected: security model remains clear and enforceable for agent use.
+- Actual: DNS resolution is delegated to proxy after preflight URL validation.
+- Current mitigation: warning plus `--require-pinned-dns`.
+- Gap: agents/users may miss warning; docs mention it but default remains weaker.
+- Recommended fix: for MCP/agent paths, default to requiring pinned DNS or require explicit `allow_proxy_dns=true`.
+- Tests: CLI config test for `--proxy --require-pinned-dns`; MCP/Fetcher test ensuring proxy warning and rejection behavior.
+
+### SEC-003: Sitemap size limit is applied after full response materialization
+
+- Severity: Medium
+- Confidence: Medium
+- Surface: sitemap fetch
+- Evidence: `_fetch_sitemap()` calls `response = await self._client.get(url)` then checks `len(response.content) > MAX_SITEMAP_SIZE` in `src/docpull/discovery/sitemap.py:132-143`.
+- Reproduction: malicious sitemap endpoint streams >50 MB but HTTP client max is higher/default 50 MB.
+- Expected: streaming cap at sitemap limit.
+- Actual: response may be read into memory up to generic client cap before sitemap-specific rejection.
+- Current mitigation: generic HTTP max content size and sitemap post-check.
+- Gap: sitemap-specific cap is not enforced during read.
+- Recommended fix: add per-request max body override to HTTP client and use 512 KB or 50 MB intentionally; document exact cap.
+- Tests: local server streaming oversized sitemap and assert early abort below memory budget.
+
+### SEC-004: Plugin docs direct users to wrong cache path, which can cause stale/private data confusion
+
+- Severity: Low
+- Confidence: High
+- Surface: Claude plugin user docs
+- Evidence: `plugin/README.md:63-65` says `$XDG_DATA_HOME/docpull/docs`; `default_docs_dir()` returns `$XDG_DATA_HOME/docpull-mcp/docs` or `~/.local/share/docpull-mcp/docs` in `src/docpull/mcp/sources.py:114-120`.
+- Reproduction: run `list_indexed()` after fetch and inspect default directory.
+- Expected: docs path matches implementation.
+- Actual: plugin docs point to a different directory.
+- Recommended fix: update plugin README and troubleshooting.
+- Tests: documentation lint or unit test asserting README contains `docpull-mcp/docs`.
+
+### SEC-005: MCP user source registry has no cross-process lock
+
+- Severity: Low
+- Confidence: High
+- Surface: `add_source` / `remove_source`
+- Evidence: `_write_user_sources()` notes "Last writer wins - no cross-process lock" in `src/docpull/mcp/tools.py:721-728`.
+- Reproduction: concurrent MCP/server/manual writes to `sources.yaml`.
+- Expected: no lost updates.
+- Actual: possible lost update.
+- Current mitigation: atomic replace prevents partial file.
+- Recommended fix: file lock around read-modify-write or document single-writer assumption.
+- Tests: concurrent add/remove simulation with lock.
+
+### SEC-006: `read_doc` large-file guard prevents full reads but allows slice request only after size rejection
+
+- Severity: Info
+- Confidence: Medium
+- Surface: MCP `read_doc`
+- Evidence: `read_doc` rejects any file >1 MB before reading even if line slice is requested in `src/docpull/mcp/tools.py:666-671`.
+- Risk: availability/usability rather than confidentiality; users cannot inspect large files via safe slice.
+- Recommended fix: when `line_start`/`line_end` is present, stream line-by-line up to requested range with byte budget.
+
+## v4.0.0 Security Claim Verification
+
+- DNS-rebinding TOCTOU fix: Verified statically in `UrlValidator.resolve_allowed_addresses()` and `_ValidatedResolver`.
+- Wider SSRF coverage: Verified statically for CGNAT, IPv4-mapped IPv6, root-dot hostnames; TS MCP additionally blocks `nip.io`, `sslip.io`, `xip.io`.
+- robots.txt body cap: Verified in `RobotsChecker.MAX_ROBOTS_SIZE`.
+- YAML frontmatter injection fix: Verified in `FrontmatterBuilder._inline()` and list item quoting.
+- Conditional request header sanitization: Present by grep in `FetchStep`; runtime unverified due import failure.
+- Release/dependency hardening: Verified workflows and `requirements-release.txt` presence; `pip-audit` could not run due DNS.
+

--- a/audit/03_SECURITY_REVIEW.md
+++ b/audit/03_SECURITY_REVIEW.md
@@ -111,4 +111,3 @@ Primary attacker capabilities:
 - YAML frontmatter injection fix: Verified in `FrontmatterBuilder._inline()` and list item quoting.
 - Conditional request header sanitization: Present by grep in `FetchStep`; runtime unverified due import failure.
 - Release/dependency hardening: Verified workflows and `requirements-release.txt` presence; `pip-audit` could not run due DNS.
-

--- a/audit/04_TEST_PLAN.md
+++ b/audit/04_TEST_PLAN.md
@@ -57,4 +57,3 @@ P2:
 - `tests/test_mcp_server.py::test_all_tools_have_annotations_and_output_schemas`
 - `tests/test_mcp_server.py::test_progress_token_forwarding`
 - `mcp/src/server.test.ts::ensure_docs_times_out_child_process`
-

--- a/audit/04_TEST_PLAN.md
+++ b/audit/04_TEST_PLAN.md
@@ -1,0 +1,60 @@
+# Test Plan
+
+## Current Inventory
+
+- Python source files: 60.
+- Python test files: 22.
+- Test definitions/classes counted by grep: 161.
+- Categories present: CLI, config, integration, discovery, link extractors, conversion, special cases, pipeline, chunking, cache conditional GET, MCP tools/server, security hardening, CI policy, real-site regressions, benchmark/performance, SQLite/NDJSON in dirty worktree.
+
+## Baseline Results
+
+- `pytest -q`: failed during collection with 11 errors, all rooted in `NameError: name 'FetchEvent' is not defined`.
+- `pytest --cov=src/docpull --cov-report=term-missing`: failed during collection for same reason.
+- `ruff check .`: failed with 11 issues, including `F821 Undefined name FetchEvent`, `F821 Undefined name SkipReason`, import sorting, line length, and unused import.
+- `mypy src/docpull`: failed with 3 errors in dirty worktree.
+- `bandit -r src/docpull`: found 8 low-severity `assert_used` findings; pyproject has a documented skip policy for B101 at `pyproject.toml:182-197`, but the local command did not pass `-c pyproject.toml`.
+- `pip-audit`: failed due DNS resolution to `pypi.org`.
+
+## Missing or Weak Test Areas
+
+- CLI no-network smoke: import, `--version`, `--help`, `--doctor`, `mcp --help`.
+- Profile contract tests: `llm` strict JS behavior vs docs, mirror hierarchical naming expectation, quick profile page/depth caps.
+- Output format end-to-end tests: markdown, JSON, NDJSON, SQLite with small local server.
+- Cache/resume end-to-end tests: interrupted crawl, frontier persistence, stale fingerprint, output-dir deleted with cache retained.
+- Security edge tests: decompression bombs, root-dot hostnames in redirects, wildcard rebinding domains in Python validator, IPv4-mapped IPv6 redirects, symlinked output/cache directories, proxy + pinned DNS behavior.
+- MCP integration: all 8 tools through official client, including add/remove source, grep/read roundtrip, progress token, structured content validation.
+- Plugin bundle tests: `.claude-plugin` metadata, commands match tool names, cache path docs, slash command UX.
+- TypeScript MCP: semantic search disabled/enabled paths, DB migration tests, docpull child-process timeout, stale version field.
+- Performance tests runnable locally with opt-in env and summary artifact.
+
+## Prioritized Regression Suite
+
+P0:
+- `tests/test_cli_smoke.py::test_version_imports_cleanly`
+- `tests/test_cli_smoke.py::test_help_imports_cleanly`
+- `tests/test_cli_smoke.py::test_doctor_imports_cleanly`
+- `tests/test_profiles.py::test_llm_profile_matches_documented_js_policy`
+- `tests/test_cli.py::test_cli_naming_strategy_choices_match_config_literal`
+- `tests/test_plugin_docs.py::test_plugin_readme_cache_path_matches_sources_default`
+
+P1:
+- `tests/test_outputs_e2e.py::test_markdown_output_local_server`
+- `tests/test_outputs_e2e.py::test_json_output_schema_local_server`
+- `tests/test_outputs_e2e.py::test_ndjson_stream_stdout_flushes_per_page`
+- `tests/test_outputs_e2e.py::test_sqlite_output_schema_and_migration`
+- `tests/test_security_hardening.py::test_python_validator_blocks_wildcard_rebinding_domains_or_documents_allowance`
+- `tests/test_security_hardening.py::test_redirect_to_ipv4_mapped_private_ipv6_blocked`
+- `tests/test_security_hardening.py::test_proxy_with_require_pinned_dns_rejected`
+- `tests/test_security_hardening.py::test_oversized_sitemap_stream_aborts_before_full_read`
+
+P2:
+- `tests/test_framework_extractors.py::test_mkdocs_material_fixture`
+- `tests/test_framework_extractors.py::test_vitepress_fixture`
+- `tests/test_framework_extractors.py::test_starlight_fixture`
+- `tests/test_framework_extractors.py::test_gitbook_fixture`
+- `tests/test_framework_extractors.py::test_redoc_scalar_openapi_fixture`
+- `tests/test_mcp_server.py::test_all_tools_have_annotations_and_output_schemas`
+- `tests/test_mcp_server.py::test_progress_token_forwarding`
+- `mcp/src/server.test.ts::ensure_docs_times_out_child_process`
+

--- a/audit/05_DOCS_AND_DX_REVIEW.md
+++ b/audit/05_DOCS_AND_DX_REVIEW.md
@@ -42,4 +42,3 @@
 - Publish workflow uses tag-only trusted publishing and verifies tag matches `pyproject.toml`.
 - Actions are pinned to full SHAs in inspected workflows.
 - Issue template contact links still point to `raintree-ai/docpull`, not `raintree-technology/docpull`.
-

--- a/audit/05_DOCS_AND_DX_REVIEW.md
+++ b/audit/05_DOCS_AND_DX_REVIEW.md
@@ -1,0 +1,45 @@
+# Docs and DX Review
+
+## Accurate Claims
+
+- Install extras in README match `pyproject.toml` extras for `llm`, `trafilatura`, `mcp`, and `all`.
+- README accurately describes Python MCP 8-tool surface at `README.md:184-198`, matching `src/docpull/mcp/server.py:225-485`.
+- README security claims are mostly backed by code: SSRF, DNS pinning, XXE, CRLF, redirect auth stripping.
+- Website feature copy around zero-trust networking is backed by `UrlValidator` and `AsyncHttpClient`.
+- Changelog 4.0.0 security claims are substantially traceable to code.
+
+## Claim / Implementation Gaps
+
+- README quickstart and CLI examples cannot currently run in dirty worktree due import failure.
+- LLM profile comment says "fail-loud on JS-only pages" in `profiles.py:47-48`, but config sets `strict_js_required=False` in `profiles.py:54-57`.
+- README advertises `docpull mcp` startup, but current worktree import failure blocks it.
+- CLI help still accepts `flat` and `short` naming aliases, contradicting changelog 3.0.0 removal and `OutputConfig` literal.
+- Plugin README says cache defaults to `docpull/docs`; implementation uses `docpull-mcp/docs`.
+- Plugin README prerequisite says `docpull --version` should print `2.5.0 or newer`; current package is `4.0.0`, so this is stale.
+- README claims root `mcp/` mirror exists publicly; unable to verify public repo.
+- Website says discovered URL list is persisted and crash resumes in `web/components/Features.tsx:18-20`; current worktree contains frontier code but runtime is broken, and public-release behavior needs clean verification.
+
+## New User Friction
+
+- If installing from this dirty source tree, every CLI command fails before help.
+- `python` command is absent on this macOS environment; docs use `python -m venv`, which may require `python3`.
+- Network-restricted environments cannot run `pip install -e ".[all,dev]"` because build isolation tries to resolve setuptools from PyPI.
+- `docpull --doctor` is intended as a diagnostic but is currently blocked by package import path in script execution.
+- SQLite output is accepted by CLI/config but barely documented.
+- Authenticated docs are supported in config/CLI, but safe usage examples and secret-scoping guidance are thin.
+
+## AI-Agent DX Friction
+
+- MCP tool docs are good, but plugin slash commands rely on accurate cache/source path docs.
+- `grep_docs` is regex-only; agents may choose brittle patterns and miss relevant content.
+- No stable manifest schema/chunk IDs, making regenerated corpora hard to diff or cite.
+- No explicit crawl budget explanation in MCP responses before fetching large sources.
+
+## Packaging
+
+- `pyproject.toml` declares Python 3.10-3.14 and typed package via `py.typed`.
+- CI tests Python 3.10-3.13 but intentionally excludes 3.14 in `.github/workflows/ci.yml`.
+- Publish workflow uses tag-only trusted publishing and verifies tag matches `pyproject.toml`.
+- Actions are pinned to full SHAs in inspected workflows.
+- Issue template contact links still point to `raintree-ai/docpull`, not `raintree-technology/docpull`.
+

--- a/audit/06_PERFORMANCE_REVIEW.md
+++ b/audit/06_PERFORMANCE_REVIEW.md
@@ -1,0 +1,42 @@
+# Performance Review
+
+## Benchmarks Found
+
+- `tests/benchmarks/test_performance.py`: conversion, deduplication, pipeline, config, memory-oriented microbenchmarks.
+- `tests/benchmarks/test_10k_pages.py`: synthetic localhost 10,000-page benchmark.
+- `.github/workflows/benchmark.yml`: nightly/on-demand 10k benchmark, fails if peak RSS exceeds 200 MB or duplicate fraction is wrong.
+- README references a synthetic 10,000-page localhost site around `README.md:286`.
+
+## Benchmarks Run
+
+No performance benchmark completed. `pytest` collection fails before benchmark execution due `FetchEvent` import error.
+
+Commands attempted:
+- `pytest -q`: 11 collection errors.
+- `pytest --cov=src/docpull --cov-report=term-missing`: 11 collection errors.
+
+## Static Performance Observations
+
+- Async HTTP and streaming discovery are implemented at the architecture level.
+- NDJSON writer flushes every record in `src/docpull/pipeline/steps/save_ndjson.py:63-69`, good for streaming but potentially write-heavy for large crawls.
+- `grep_docs` reads each Markdown file into memory line lists in `src/docpull/mcp/tools.py:530-532`; acceptable for small docs, but not indexed and can be slow for large caches.
+- `read_doc` refuses files over 1 MB before reading, reducing accidental huge reads.
+- Sitemap and robots caps exist, but sitemap-specific cap is post-fetch.
+- Root TypeScript MCP uses pgvector and batch inserts under PostgreSQL bind limits in `mcp/src/db.ts:24-29` and `197-231`.
+
+## Scaling Concerns
+
+- Large documentation sets need persistent searchable index beyond regex scan.
+- NDJSON per-record flush can bottleneck on slow filesystems; batch flush option could improve throughput when not piping.
+- `countMarkdownFiles` and `rglob("*.md")` scans are repeated in MCP cache/index operations.
+- Streaming discovery/backpressure claims need runtime verification.
+- Cache/resume/frontier code in dirty worktree is not validated.
+
+## Recommended Performance Work
+
+1. Restore runnable tests and run `DOCPULL_BENCHMARK_10K=1 pytest -v -s tests/benchmarks/test_10k_pages.py`.
+2. Add a 100-page and 1,000-page local benchmark that runs by default or in CI quick mode.
+3. Add MCP grep benchmark on synthetic large cache; compare regex scan vs SQLite FTS.
+4. Add memory assertions for sitemap/robots/body caps.
+5. Add optional batch flush for NDJSON file output while preserving stdout flush.
+

--- a/audit/06_PERFORMANCE_REVIEW.md
+++ b/audit/06_PERFORMANCE_REVIEW.md
@@ -39,4 +39,3 @@ Commands attempted:
 3. Add MCP grep benchmark on synthetic large cache; compare regex scan vs SQLite FTS.
 4. Add memory assertions for sitemap/robots/body caps.
 5. Add optional batch flush for NDJSON file output while preserving stdout flush.
-

--- a/audit/07_EXPANSION_ROADMAP.md
+++ b/audit/07_EXPANSION_ROADMAP.md
@@ -1,0 +1,114 @@
+# Expansion Roadmap
+
+## P0: Correctness, Security, Documentation
+
+### Fix current import/type/lint blockers
+
+- User story: As a user, I can run `docpull --help` and `docpull --version` after installing from source.
+- Why now: Current dirty worktree is unusable.
+- Evidence: `FetchEvent` NameError in `src/docpull/models/events.py:131-140`; ruff/mypy failures.
+- Plan: add postponed annotations, import `SkipReason` where used, fix ruff/mypy issues.
+- Files: `models/events.py`, `pipeline/steps/convert.py`, `cache/frontier.py`, formatting.
+- Tests: CLI smoke, import smoke, full pytest.
+- Docs: none.
+- Risk: S.
+- Estimate: S.
+- Acceptance: `ruff check .`, `mypy src/docpull`, `pytest -q`, `docpull --help` pass.
+
+### Align LLM profile JS policy
+
+- User story: As an agent, I know whether LLM mode skips or fails JS-only pages.
+- Evidence: README/inline comment vs `strict_js_required=False`.
+- Plan: choose behavior; likely keep skip default for compatibility and update comment/README, or set true in v5.
+- Files: `profiles.py`, README, website, tests.
+- Tests: profile contract test.
+- Risk: behavior change if set true.
+- Estimate: S.
+- Acceptance: docs, comments, and config agree.
+
+### Fix CLI naming aliases
+
+- User story: As a CLI user, deprecated `flat/short` behavior is not accepted silently then rejected later.
+- Evidence: `cli.py:136-143`, `config.py:145-150`, changelog 3.0.0.
+- Plan: remove `flat/short` from argparse or map with clear error.
+- Tests: parser/config test.
+- Risk: low.
+- Estimate: S.
+- Acceptance: `docpull --help` only lists valid names.
+
+### Correct plugin docs
+
+- User story: As a Claude Code user, I can find/delete the actual cache.
+- Evidence: plugin README path mismatch.
+- Plan: update cache path, version prerequisite, and direct URL wording.
+- Tests: docs lint.
+- Estimate: S.
+
+## P1: High-Impact Low-Risk
+
+### Stable corpus manifest and chunk IDs
+
+- User story: As a RAG builder, I can diff and cite regenerated docs reliably.
+- Code seam: `DocumentRecord`, `RunIdentity`, `NdjsonSaveStep`, `SqliteSaveStep`.
+- Plan: add `manifest.json`, stable chunk IDs from URL+heading+chunk index+content hash.
+- Tests: deterministic rerun tests.
+- Docs: output schema page.
+- Estimate: M.
+
+### SQLite FTS search path
+
+- User story: As an agent, I can search cached docs faster than regex scan without Postgres.
+- Code seam: `save_sqlite.py`, MCP `grep_docs`.
+- Plan: create SQLite FTS5 index; add optional MCP source `search_docs` or faster grep.
+- Tests: FTS ranking, migration, path validation.
+- Estimate: M.
+
+### Per-project MCP cache
+
+- User story: As a team, each repo has its own docs snapshot.
+- Code seam: `default_docs_dir()`, plugin config, commands.
+- Plan: support `.docpull/docs` or env/config override in plugin commands.
+- Tests: XDG/env/project precedence.
+- Estimate: M.
+
+### Framework extractor fixture suite
+
+- User story: As a user, DocPull handles common docs frameworks predictably.
+- Targets: MkDocs/Material, VitePress, VuePress, Astro/Starlight, GitBook, ReadMe.io, Redoc/Scalar.
+- Code seam: `conversion/special_cases.py`.
+- Plan: add local HTML fixtures before live extractors.
+- Tests: one fixture per framework.
+- Estimate: M.
+
+## P2: Strategic Expansion
+
+### Optional JS rendering adapter
+
+- User story: As a user, JS-only docs can be fetched when I explicitly opt in.
+- Plan: keep browser-free default; add Playwright/Browserless adapter behind extra and strict domain/budget controls.
+- Risk: security, cost, flakiness.
+- Estimate: L.
+- Acceptance: JS-only local fixture succeeds only with adapter enabled.
+
+### Authenticated/internal docs mode
+
+- User story: As an enterprise user, I can fetch private docs safely.
+- Plan: allowlist domains, scoped headers/cookies, redaction, audit log, no cross-origin auth, privacy mode.
+- Files: config, HTTP, docs, MCP tools.
+- Risk: high.
+- Estimate: L/XL.
+
+### Semantic search product path
+
+- User story: As an agent, I can ask conceptual questions over cached docs.
+- Plan: decide whether root `mcp/` becomes official or Python MCP gains optional embeddings adapters.
+- Dependencies: OpenAI/local embeddings/vector DB.
+- Estimate: L.
+
+## P3: Speculative Bets
+
+- Malicious-doc detection/redaction.
+- Provenance attestations for generated corpora.
+- GitHub Actions scheduled refresh workflow generator.
+- IDE integrations beyond Claude/Cursor.
+

--- a/audit/07_EXPANSION_ROADMAP.md
+++ b/audit/07_EXPANSION_ROADMAP.md
@@ -111,4 +111,3 @@
 - Provenance attestations for generated corpora.
 - GitHub Actions scheduled refresh workflow generator.
 - IDE integrations beyond Claude/Cursor.
-

--- a/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
+++ b/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
@@ -14,4 +14,3 @@
 | Production/stable classifier | `pyproject.toml:24-27` | Dirty worktree is not runnable | Gap for current workspace | Do not release until clean gates pass |
 | All tools with data return structuredContent | `README.md:198` | Implemented for most tools; `fetch_url` intentionally has no output schema | Mostly accurate | Wording should say all schema-backed tools |
 | Website/product says production-grade ingestion | `web/components/Features.tsx:37-39` | Strong design, but current worktree broken | Gap for current workspace | Ship patch after gates |
-

--- a/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
+++ b/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
@@ -1,0 +1,17 @@
+# Claim / Implementation Gaps
+
+| Claim | Source | Actual Evidence | Status | Fix |
+|---|---|---|---|---|
+| Current runtime supports CLI help/version/doctor | README quickstart and CLI docs | Current worktree commands fail importing `FetchEvent` | Broken | Fix annotation/import blocker and add smoke tests |
+| LLM profile is fail-loud on JS-only pages | `profiles.py:47-48` comment and README agent positioning | `strict_js_required=False` at `profiles.py:54-57` | Gap | Align docs/comment/config |
+| `flat`/`short` naming aliases removed in 3.0 | `docs/CHANGELOG.md:118-120` | CLI still accepts them at `cli.py:136-143`; config rejects them | Gap | Remove from CLI choices |
+| Plugin cache path is `$XDG_DATA_HOME/docpull/docs` | `plugin/README.md:63-65` | Python MCP uses `docpull-mcp/docs` at `sources.py:114-120` | Gap | Update plugin README |
+| Plugin prerequisite should print `2.5.0 or newer` | `plugin/README.md:27` | Package is 4.0.0; plugin metadata version 0.2.0 | Stale | Update prerequisite/version docs |
+| Root `mcp/` mirrored to public `docpull-mcp` repo | `README.md:211-219`, `mcp/package.json:35-38` | Public mirror not verified in browser/search | Unverified | Make repo public or mark private/unavailable |
+| TypeScript MCP server version is 0.3.0 | `mcp/package.json:2-3` | `mcp/src/server.ts:396` says version `0.2.0` | Gap | Single-source version |
+| Website says discovered URL list is persisted for crash resume | `web/components/Features.tsx:18-20` | Dirty worktree has `frontier.py`, but import failure blocks verification | Unverified/Broken | Stabilize frontier and add e2e resume test |
+| Sphinx detected/tagged | `README.md:64-65` | No directly inspected Sphinx extractor evidence in `special_cases.py` snippet | Unverified | Add explicit Sphinx test/code reference or remove claim |
+| Production/stable classifier | `pyproject.toml:24-27` | Dirty worktree is not runnable | Gap for current workspace | Do not release until clean gates pass |
+| All tools with data return structuredContent | `README.md:198` | Implemented for most tools; `fetch_url` intentionally has no output schema | Mostly accurate | Wording should say all schema-backed tools |
+| Website/product says production-grade ingestion | `web/components/Features.tsx:37-39` | Strong design, but current worktree broken | Gap for current workspace | Ship patch after gates |
+

--- a/audit/09_ISSUE_BACKLOG.md
+++ b/audit/09_ISSUE_BACKLOG.md
@@ -1,0 +1,106 @@
+# Issue Backlog
+
+## P0
+
+### Import failure blocks all CLI/API/MCP use
+
+- Labels: `bug`, `tests`, `dx`
+- Severity: critical
+- Evidence: `src/docpull/models/events.py:131-140`; command failures.
+- Repro: `./.venv/bin/docpull --version`.
+- Expected: `docpull 4.0.0`.
+- Actual: `NameError: name 'FetchEvent' is not defined`.
+- Fix: postponed annotations or quoted return type; add smoke tests.
+
+### Ruff/mypy failures in dirty worktree
+
+- Labels: `bug`, `tests`, `dx`
+- Severity: high
+- Evidence: ruff F821 for `FetchEvent` and `SkipReason`; mypy 3 errors.
+- Repro: `ruff check .`; `mypy src/docpull`.
+- Fix: imports/annotations/typing cleanup.
+
+### LLM profile docs disagree with behavior
+
+- Labels: `docs`, `bug`
+- Severity: medium
+- Evidence: `profiles.py:47-57`.
+- Fix: align config/docs/comment.
+
+### CLI accepts removed naming aliases
+
+- Labels: `bug`, `dx`, `docs`
+- Severity: medium
+- Evidence: `cli.py:136-143`, `config.py:145-150`, changelog 3.0.0.
+- Fix: remove or explicitly reject aliases.
+
+### Plugin README cache path is wrong
+
+- Labels: `plugin`, `docs`, `dx`
+- Severity: medium
+- Evidence: `plugin/README.md:63-65`, `mcp/sources.py:114-120`.
+- Fix: update docs and add regression check.
+
+## P1
+
+### Verify and document root TypeScript MCP status
+
+- Labels: `mcp`, `architecture`, `docs`
+- Severity: medium
+- Evidence: README mirror claim unverified; TS/Python MCP duplicate tools.
+- Fix: split/private/experimental decision and README update.
+
+### Add CLI no-network smoke tests
+
+- Labels: `tests`, `dx`
+- Severity: high
+- Evidence: current import failure escaped.
+- Fix: test `--version`, `--help`, `--doctor`, `mcp --help`.
+
+### Add output format e2e suite
+
+- Labels: `tests`, `feature`
+- Severity: medium
+- Evidence: formats claimed; runtime not verified.
+- Fix: localhost fixture for markdown/json/ndjson/sqlite.
+
+### Add proxy-mode security tests/docs
+
+- Labels: `security`, `tests`, `docs`
+- Severity: medium
+- Evidence: proxy disables resolver pinning by design.
+- Fix: tests and explicit agent guidance.
+
+### Add SQLite/FTS or indexed grep
+
+- Labels: `performance`, `mcp`, `feature`
+- Severity: medium
+- Evidence: MCP grep scans files line-by-line.
+- Fix: optional FTS index.
+
+## P2
+
+### Add framework fixture extractors
+
+- Labels: `feature`, `tests`
+- Severity: medium
+- Targets: MkDocs, VitePress, VuePress, Starlight, GitBook, ReadMe.io, Redoc/Scalar.
+
+### Add corpus manifest and stable chunk IDs
+
+- Labels: `feature`, `architecture`
+- Severity: medium
+- Fix: manifest schema, source maps, deterministic chunk IDs.
+
+### Authenticated/internal docs mode
+
+- Labels: `feature`, `security`
+- Severity: high
+- Fix: allowlists, scoped secrets, redaction, audit logs.
+
+### Optional JS renderer
+
+- Labels: `feature`, `security`, `performance`
+- Severity: strategic
+- Fix: Playwright/Browserless adapter behind explicit extra and policy.
+

--- a/audit/09_ISSUE_BACKLOG.md
+++ b/audit/09_ISSUE_BACKLOG.md
@@ -103,4 +103,3 @@
 - Labels: `feature`, `security`, `performance`
 - Severity: strategic
 - Fix: Playwright/Browserless adapter behind explicit extra and policy.
-

--- a/audit/10_AGENT_CONTEXT_BRIEF.md
+++ b/audit/10_AGENT_CONTEXT_BRIEF.md
@@ -1,0 +1,31 @@
+# Agent Context Brief
+
+DocPull is a Python 3.10+ package/CLI at version 4.0.0. It fetches static docs over async HTTP, validates URLs, respects robots.txt, converts to Markdown/JSON/NDJSON/SQLite-style records, and ships a Python stdio MCP server. The repo also contains a separate Bun/TypeScript `mcp/` semantic-search MCP with Postgres/pgvector and a Claude Code plugin.
+
+Current workspace is dirty and broken. Do not assume it represents clean public 4.0.0. `docpull --version`, `--help`, `--doctor`, `pytest`, and coverage all fail because `src/docpull/models/events.py` references `FetchEvent` in a return annotation before the class exists. Fix this before any feature work.
+
+Core flow: CLI -> `DocpullConfig` -> `Fetcher` -> `UrlValidator`/`RobotsChecker`/`AsyncHttpClient` -> sitemap/link discovery -> `FetchPipeline` -> validate/fetch/convert/metadata/dedup/chunk/save.
+
+Security model: HTTPS-only, private/internal/localhost/CGNAT/IPv4-mapped IPv6 blocks, DNS root-dot stripping, connect-time DNS pinning via aiohttp resolver, redirect revalidation, cross-origin auth stripping, robots pinned fetch, defusedxml for sitemap XML, YAML frontmatter sanitization, MCP path and regex guards.
+
+Highest-priority gaps:
+- Fix import/lint/type/test failures.
+- Align LLM profile JS-only behavior with docs.
+- Remove CLI `flat`/`short` naming aliases or update config/docs.
+- Fix plugin cache path docs: implementation uses `~/.local/share/docpull-mcp/docs`.
+- Decide/document root TypeScript MCP status; public mirror claim is unverified.
+
+Useful commands after fixing import blocker:
+
+```bash
+./.venv/bin/docpull --version
+./.venv/bin/docpull --help
+./.venv/bin/docpull --doctor
+./.venv/bin/pytest -q
+./.venv/bin/ruff check .
+./.venv/bin/mypy src/docpull
+./.venv/bin/bandit -q -c pyproject.toml -r src
+```
+
+Do not run uncontrolled crawls. Use localhost fixtures and `--single` / `--max-pages`.
+

--- a/audit/10_AGENT_CONTEXT_BRIEF.md
+++ b/audit/10_AGENT_CONTEXT_BRIEF.md
@@ -28,4 +28,3 @@ Useful commands after fixing import blocker:
 ```
 
 Do not run uncontrolled crawls. Use localhost fixtures and `--single` / `--max-pages`.
-

--- a/audit/2026-06-06-current-audit.md
+++ b/audit/2026-06-06-current-audit.md
@@ -1,0 +1,366 @@
+# DocPull Current Audit - 2026-06-06
+
+Scope: local repo at `/Users/mb1/Code/secondary/docpull`, product site `https://docpull.raintree.technology/`, PyPI package `docpull`, GitHub repo `raintree-technology/docpull`, Python MCP under `src/docpull/mcp/`, root TypeScript/Bun MCP under `mcp/`, Claude plugin docs under `plugin/`.
+
+## Executive Summary
+
+DocPull is a Python 3.10+ CLI/library that crawls static or server-rendered documentation over async HTTP, applies URL/robots/security policy, extracts main content, converts to Markdown-oriented records, and writes Markdown, JSON, NDJSON, or SQLite outputs. It also ships a package-installed Python stdio MCP server for agent workflows. The repository additionally contains a separate Bun/TypeScript MCP server with PostgreSQL/pgvector semantic search and a Claude Code plugin bundle.
+
+Current version is verified as `4.0.0`:
+- Local metadata: `pyproject.toml:6-7`, `src/docpull/__init__.py:17`, `python -m pip show docpull`.
+- Runtime: `docpull --version` prints `docpull 4.0.0`.
+- PyPI JSON and project page report latest `4.0.0`, released 2026-06-04.
+- Local git log includes `a3a288e chore(release): 4.0.0 (#48)`.
+
+The current local worktree is not clean:
+- `git status --short --branch`: `main...origin/main [ahead 2, behind 1]`, untracked `.claude-plugin/plugin/`, untracked `audit/`.
+- This audit did not reset, clean, or modify product code.
+
+Overall assessment before the follow-up fixes: the Python package was in good shape for a CLI/library/security posture, with green tests/lint/type/dependency audit in this environment. The main risks were claim drift and product-boundary confusion: stale published README copy about `docpull-mcp`, the root TypeScript MCP tree pointing to a public repo that returned 404, a mirror-profile naming mismatch, security skips returning exit code 0 for invalid targets, and a few docs/product claims that were broader than verified behavior. The concrete items from that list have now been fixed locally; publishing a new package release is still required to replace the older PyPI long description.
+
+## Resolution Update
+
+The implementation pass after this audit closed the concrete claim/implementation gaps called out below:
+
+- Mirror profile now defaults to hierarchical output paths while preserving explicit user overrides.
+- `--single` now exits nonzero for URL-validation and robots-policy skips.
+- `--insecure-tls` help now accurately says the flag is deprecated and rejected.
+- README, plugin docs, root `mcp/` docs/package metadata, and web profile copy no longer claim unavailable mirrors or fail-loud defaults that are not true.
+- Sphinx wording now cites the actual detection basis: generator metadata and Read the Docs hosts.
+- Robots `Crawl-delay` is now applied to the start host's rate limiter using the stricter of configured `rate_limit` and robots delay.
+- Regression coverage was added for mirror profile defaults/overrides, CLI help text, invalid single-URL exit behavior, and crawl-delay limiter wiring.
+
+Post-fix gates passed: `pytest -q` (`359 passed`), `ruff check .`, `mypy src/docpull`, `bandit -c pyproject.toml -r src/docpull`, `pip-audit`, and web `npm run lint && npm run typecheck && npm run build`.
+
+## Baseline Commands
+
+Requested command `python -m venv .venv` failed because `python` is not on PATH in this shell:
+
+```text
+zsh:1: command not found: python
+```
+
+Equivalent setup with `python3` succeeded:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e '.[all,dev]'
+```
+
+Baseline verification:
+
+| Command | Exit | Result |
+|---|---:|---|
+| `python -m pip show docpull` | 0 | Editable `docpull==4.0.0`; location `.venv/lib/python3.11/site-packages`; editable project location is repo root. |
+| `docpull --version` | 0 | `docpull 4.0.0`. |
+| `docpull --help` | 0 | Shows profiles `rag, mirror, quick, llm`; formats `markdown,json,ndjson,sqlite`; auth flags; cache; chunking; `--skill`; `--require-pinned-dns`. |
+| `docpull --doctor` | 0 | Core and optional deps OK; network connectivity OK; output dir writable. |
+| `pytest -q` | 0 | `353 passed in 10.48s`. |
+| `ruff check .` | 0 | All checks passed. |
+| `mypy src/docpull` | 0 | Success, 61 source files. |
+| `bandit -r src/docpull` | 1 | 8 low-severity `B101 assert_used` findings in `fetcher.py` and `convert.py`; `pyproject.toml:182-197` documents a repo policy to skip B101, but the requested command did not pass `-c pyproject.toml`. |
+| `pip-audit` | 0 | No known vulnerabilities found. |
+
+The intended Bandit command for repo policy should be `bandit -c pyproject.toml -r src/docpull`.
+
+## Claim Matrix
+
+| Claim | Source | Category | Verification | Status | Evidence / Risk / Fix |
+|---|---|---|---|---|---|
+| Browser-free async HTTP crawler for static/server-rendered docs | README, PyPI, site | CLI/functionality | Static + runtime | Verified | `AsyncHttpClient` in `src/docpull/http/client.py`; site says browser-free; `docpull https://example.com --single` succeeded. |
+| Clean Markdown with YAML frontmatter source URL | README/site | Output | Runtime | Verified | Markdown output contained `title`, `source`, `headings`, `crawled_at`; save path `index.md`. |
+| Formats `markdown`, `json`, `ndjson`, `sqlite` | README/CLI | Output | Runtime | Verified | Representative `https://example.com --single` produced `index.md`, `documents.json`, `documents.ndjson`, and `documents.db`; all exit 0. |
+| Every output format writes `corpus.manifest.json` | README | Output | Runtime + code | Verified for markdown/json/ndjson/sqlite | Runtime markdown emitted manifest; output tests cover json/ndjson/sqlite; savers use `CorpusManifest`. |
+| `--stream` streams NDJSON to stdout | README/CLI | Agent output | Runtime | Verified | `docpull https://example.com --single --profile llm --stream --quiet` emitted one NDJSON line with `chunk_id`, `token_count`, `chunk_index`. |
+| LLM profile is chunked NDJSON metadata output | README/profiles | Output/profile | Runtime + code | Verified | `src/docpull/models/profiles.py:47-64` sets format `ndjson`, rich metadata, max tokens 4000, emit chunks; runtime confirmed chunk record. |
+| LLM profile is fail-loud on JS-only pages | Live site said "fail-loud"; profile comment says JS-only skipped by default | Product/profile | Code | Resolved post-audit | Web copy now says LLM skips JS-only pages unless strict mode is enabled. |
+| Mirror profile defaults to hierarchical naming | CLI help says mirror defaults hierarchical | CLI/profile | Runtime | Resolved post-audit | Mirror profile now sets `output.naming_strategy = "hierarchical"` while explicit user overrides still win. |
+| `--single` fetches one URL without discovery | README/CLI | CLI | Runtime + code | Verified | `Fetcher.fetch_one()` bypasses discovery in `src/docpull/core/fetcher.py:515-550`; runtime examples succeeded. |
+| `--include-paths` / `--exclude-paths` filter discovery | README/CLI/site | Discovery | Static/tests | Verified by implementation, not separately runtime-tested in this pass | CLI maps to `PatternFilter`; `Fetcher.__aenter__` creates it at `src/docpull/core/fetcher.py:414-420`. |
+| Sitemap discovery, sitemap index recursion, XXE protection | README/security/code | Discovery/security | Static/tests | Verified by code/tests | `src/docpull/discovery/sitemap.py:9-43`, `149-186`; `defusedxml`, size/depth limits. |
+| Mandatory robots.txt compliance | README/security/site | Security | Static/tests | Verified | `ValidateStep` receives `RobotsChecker`; robots checker fail-closes on errors, allows missing 4xx, caps 512 KB in `src/docpull/security/robots.py`. |
+| Crawl-delay handling | User audit checklist | Discovery | Static + tests | Resolved post-audit | `Fetcher._apply_robots_crawl_delay()` now applies robots delay to the start host's rate limiter using the stricter delay. |
+| HTTPS-only, SSRF, DNS-rebinding protection | README/PyPI/security | Security | Static + runtime | Verified | `UrlValidator` blocks non-HTTPS/private/local/CGNAT/IPv4-mapped; `_ValidatedResolver` pins allowed addresses; runtime `http://example.com` and `https://localhost` were skipped with validation reasons. |
+| Unsafe URL should fail command | Security expectation for agent tooling | DX/security | Runtime | Resolved post-audit | `--single` now returns nonzero for URL-validation and robots-policy skips. |
+| `--insecure-tls` disables TLS | CLI help said "Disable TLS certificate verification (unsafe)" | Security/CLI | Runtime + code | Resolved post-audit | Help now says the flag is deprecated and rejected. |
+| Proxy delegates DNS pinning unless `--require-pinned-dns` | README/security | Security | Runtime + code | Verified | Runtime proxy + require pinned DNS exits 1; code warns in `AsyncHttpClient.__aenter__`. |
+| Auth headers stripped on cross-origin redirects | README/security | Security | Static/tests | Verified | `src/docpull/http/client.py:209-235`; tests cover off-scope stripping. |
+| Rich metadata extraction | README/site | Metadata | Static/tests | Verified by code, partial runtime | `MetadataStep` + `metadata_extractor.py`; runtime basic page metadata present; rich OG/JSON-LD not separately fixture-tested in this pass. |
+| Code blocks, language hints, tables, images, cookie banners | Site FAQ | Conversion | Static/tests | Partially verified | Conversion stack has extractor/converter and tests, but this pass did not exhaustively fixture each FAQ item. Keep claim but add explicit fixture coverage. |
+| Framework extractors: Next.js, Mintlify, OpenAPI, Docusaurus, Sphinx | README | Extraction | Static/tests | Partial | Next/Mintlify/OpenAPI code is clear in `special_cases.py`; Docusaurus is detection/tagging only via generic fallback; Sphinx was not confirmed in inspected code. Add explicit Sphinx evidence/test or soften claim. |
+| JS-only SPA detected and skipped / strict error | README/site | Extraction | Static/code | Verified by code, runtime not fixture-tested | `ConvertStep._handle_empty_content()` and `looks_like_spa` path. |
+| Python API `fetch_one`, `Fetcher`, `DocpullConfig`, async events | README | API | Static + import | Verified | Exported in `src/docpull/__init__.py:19-33`; `fetch_one()` sync wrapper at `src/docpull/core/fetcher.py:957-990`. |
+| Python package is typed | PyPI classifier | Packaging | Static | Verified | `src/docpull/py.typed`; `pyproject.toml:140-141`; mypy passes. |
+| MCP server ships in Python package | README/plugin | MCP | Runtime + tests | Verified | `docpull mcp --help` works; `tests/test_mcp_server.py` verifies 8 tools and SSRF rejection. |
+| MCP tools: 8 total, annotations, structured output | README | MCP | Static/tests | Mostly verified | Server declares 8 tools with annotations/output schemas; `fetch_url` intentionally omits output schema. Wording "all tools that carry data" should be "schema-backed tools" or add schema to `fetch_url`. |
+| User sources in `~/.config/docpull-mcp/sources.yaml` | README/MCP | MCP | Static | Verified | `src/docpull/mcp/sources.py` defaults and loaders. |
+| Plugin cache path is `$XDG_DATA_HOME/docpull/docs` | `plugin/README.md:63-65` | Plugin docs | Static | Resolved post-audit | Plugin README now uses `docpull-mcp/docs`. |
+| Plugin prerequisite "2.5.0 or newer" | `plugin/README.md:27` | Plugin docs | Static | Resolved post-audit | Plugin README now says `4.0.0 or newer`. |
+| Root `mcp/` mirror exists at `raintree-technology/docpull-mcp` | Published PyPI README and old `mcp/README.md`/package metadata | Packaging/docs | Live HTTP | Resolved locally; pending release | Local root MCP docs/package metadata now point to the in-repo `mcp/` directory under `raintree-technology/docpull`; PyPI will remain stale until the next release. |
+| 10k pages in about 27s, 28 MB RSS | README/site | Performance | Static/tests | Not rerun; benchmark exists | `tests/benchmarks/test_10k_pages.py` contains gated benchmark and assertions. This audit did not run 10k benchmark to avoid heavier crawl. Treat published numbers as benchmark-derived but not freshly measured. |
+| No telemetry/local-first/no remote services | README/plugin/site | Privacy/product | Static | Mostly verified for Python CLI | Python CLI makes requested HTTP calls only; root TypeScript MCP uses OpenAI embeddings when semantic indexing is enabled, so product copy should keep Python package and TS MCP boundaries clear. |
+
+## Architecture Map
+
+Top-level structure:
+- `src/docpull/`: Python package, public API, CLI, security, HTTP, discovery, conversion, pipeline, cache, MCP.
+- `tests/`: unit/e2e/security/MCP/output tests.
+- `tests/benchmarks/`: synthetic performance benchmarks.
+- `mcp/`: separate Bun/TypeScript MCP server with PostgreSQL/pgvector/OpenAI semantic search.
+- `plugin/`: Claude Code plugin documentation; untracked `.claude-plugin/plugin/` appears to contain built plugin output.
+- `web/`: Next.js product site.
+- `.github/`: CI, publish, CodeQL, metrics, security workflows.
+
+Python package structure and responsibilities:
+- `cli.py`: argparse surface, maps CLI flags into `DocpullConfig`, dispatches normal fetch or `docpull mcp`.
+- `models/config.py`: Pydantic config objects: crawl, content filter, output, network, auth, performance, cache.
+- `models/profiles.py`: profile defaults for `rag`, `mirror`, `quick`, `llm`, `custom`.
+- `core/fetcher.py`: orchestration; builds validator, robots checker, HTTP client, pipeline, discoverers; exposes `run()`, `discover()`, `fetch_one()`, sync wrappers.
+- `security/url_validator.py`: HTTPS policy, hostname/IP validation, DNS screening, connect-time address list.
+- `security/robots.py`: robots.txt fetch/parse/cache with pinned HTTPS and fail-closed errors.
+- `http/client.py`: aiohttp client, validated resolver, redirect validation, auth scoping, retry/timeout/content caps.
+- `discovery/`: sitemap and link crawling, pattern/domain/seen filters, composite fallback.
+- `conversion/`: main content extraction, html2text conversion, trafilatura adapter, framework special cases, chunking.
+- `metadata_extractor.py`: title/description/OpenGraph/JSON-LD/microdata metadata.
+- `pipeline/base.py`: `PageContext`, `FetchPipeline`, step protocol.
+- `pipeline/steps/`: validate, fetch, metadata, convert, dedup, chunk, save markdown/json/ndjson/sqlite.
+- `cache/`: HTTP cache state, frontier/resume, streaming dedup.
+- `mcp/`: package-shipped Python stdio MCP server, tools, source registry.
+
+Runtime data flow:
+
+```text
+CLI/API input URL
+  -> DocpullConfig + profile defaults
+  -> Fetcher.__aenter__
+  -> UrlValidator + RobotsChecker + AsyncHttpClient
+  -> CompositeDiscoverer
+       -> SitemapDiscoverer from robots Sitemap or guessed sitemap locations
+       -> LinkCrawler fallback/static link extraction
+  -> FetchPipeline per URL
+       -> ValidateStep: URL policy + robots + cache existing
+       -> FetchStep: HTTP GET + conditional headers/cache response handling
+       -> MetadataStep: title/OG/JSON-LD/microdata
+       -> ConvertStep: source detection -> special cases/trafilatura/generic -> frontmatter
+       -> DedupStep: optional streaming duplicate skip
+       -> ChunkStep: optional token chunks
+       -> SaveStep / JsonSaveStep / NdjsonSaveStep / SqliteSaveStep
+  -> CorpusManifest finalization + cache/frontier flush
+  -> FetchEvent stream + FetchStats
+```
+
+Trust boundaries:
+- User/agent-provided URL crosses into `UrlValidator`; default allows only HTTPS and public network destinations.
+- DNS is resolved by `UrlValidator.resolve_allowed_addresses()` and reused by `_ValidatedResolver` when no proxy is configured.
+- Proxy mode shifts DNS trust to the proxy; `--require-pinned-dns` rejects that mode.
+- Redirect targets are revalidated and sensitive auth headers are stripped across origin changes.
+- robots.txt and sitemaps are untrusted network inputs: robots has body cap; sitemap uses `defusedxml`, size/depth caps, URL validation.
+- HTML/JSON-LD/OpenAPI inputs are untrusted: conversion and metadata extraction should never execute scripts; frontmatter list values are sanitized.
+- Output paths are derived from sanitized URL segments and validated under base output dir.
+- MCP tools take agent-controlled strings; Python MCP validates URLs, source names, library names, regex size/time, and read paths.
+- Root TypeScript MCP adds database and OpenAI API trust boundaries separate from Python package.
+
+Extension points:
+- Add `SpecialCaseExtractor` implementations to `DEFAULT_CHAIN`.
+- Swap extractor via `--extractor trafilatura`.
+- Add output savers through pipeline step pattern.
+- Add profiles in `models/profiles.py`.
+- Add MCP tools in `src/docpull/mcp/server.py` + `tools.py`.
+- Add discovery sources/extractors through discoverer protocols and link extractor protocols.
+
+Dead/duplicated systems:
+- Python MCP and root TypeScript MCP are separate MCP products with overlapping names/source concepts but different persistence and search models.
+- Root `mcp/` still documents clone of `docpull-mcp` and metadata points to a GitHub repo currently returning 404.
+- CLI still exposes `--insecure-tls` but rejects it.
+- Existing untracked `audit/*.md` files are stale relative to this run; they mention an import break that is no longer present.
+
+## Functional Verification
+
+Verified locally:
+- Install editable with all/dev extras under Python 3.11.
+- CLI `--version`, `--help`, `--doctor`.
+- Full test suite: 353 passed.
+- Static quality: ruff/mypy pass.
+- Dependency audit: no known vulnerabilities.
+- Bandit: only B101 asserts surfaced under the raw requested command.
+- `docpull mcp --help`.
+- `--single` markdown/json/ndjson/sqlite against `https://example.com`.
+- `--profile llm --stream` emitted chunked NDJSON to stdout.
+- Security rejection messages for `http://example.com`, `https://localhost`, `--insecure-tls`, and proxy + `--require-pinned-dns`.
+
+Not exhaustively rerun in this pass:
+- 10k benchmark.
+- Every framework extractor fixture.
+- Auth against a real protected docs site.
+- Invalid cert and 404 live cases.
+- Proxy success path.
+- Complete include/exclude/depth/backpressure behavior outside tests.
+- Root TypeScript MCP runtime with PostgreSQL/OpenAI.
+- Product-site browser interaction beyond HTML fetch.
+
+## Issue-Ready Findings
+
+### P1 - Resolved Locally: public PyPI README still claims a `docpull-mcp` mirror that returns 404
+
+Severity: High  
+Confidence: High  
+Evidence:
+- PyPI project page for `4.0.0` says the root `mcp/` tree is mirrored to `raintree-technology/docpull-mcp`.
+- `curl -I -L https://github.com/raintree-technology/docpull-mcp` returned HTTP 404.
+- Local `mcp/README.md:17-18` tells users to `git clone https://github.com/raintree-technology/docpull-mcp`.
+- Local `mcp/package.json:35-38` points repository metadata at the same URL.
+- Local top-level `README.md` has already been softened to say no public mirror is claimed, but that fix is not reflected in the published PyPI long description.
+
+Reproduction:
+1. Open `https://pypi.org/project/docpull/`.
+2. Search for `docpull-mcp`.
+3. Open `https://github.com/raintree-technology/docpull-mcp`.
+
+Expected: linked mirror exists, or docs clearly say the mirror is private/unavailable.  
+Actual: public package metadata points users to a 404.  
+Resolution: local `mcp/README.md` and `mcp/package.json` now point to the in-repo `mcp/` directory under the main `docpull` repository. A package release is still needed to replace the older PyPI long description.
+
+### P1 - Resolved: mirror profile naming claim was false
+
+Severity: Medium  
+Confidence: High  
+Evidence:
+- CLI help says mirror profile defaults to hierarchical naming.
+- `src/docpull/models/profiles.py:22-38` intentionally does not set `output.naming_strategy`.
+- Runtime check returned `naming_strategy full` for `Fetcher(DocpullConfig(profile=ProfileName.MIRROR))`.
+
+Reproduction:
+```bash
+. .venv/bin/activate
+python - <<'PY'
+from docpull import DocpullConfig, Fetcher, ProfileName
+print(Fetcher(DocpullConfig(url="https://example.com", profile=ProfileName.MIRROR)).config.output.naming_strategy)
+PY
+```
+
+Expected: either `hierarchical` or docs do not claim mirror defaults hierarchical.  
+Actual: `full`.  
+Resolution: mirror now defaults to hierarchical output paths, with a regression test proving explicit `full` overrides still win.
+
+### P1 - Resolved: security validation skips returned exit code 0 in `--single`
+
+Severity: Medium  
+Confidence: High  
+Evidence:
+- `docpull http://example.com --single` exits 0 with `Skipped: URL validation failed: Scheme 'http' not allowed`.
+- `docpull https://localhost --single` exits 0 with `Skipped: URL validation failed: Localhost URLs not allowed`.
+- `src/docpull/cli.py:552-558` returns 0 on any `ctx.should_skip`.
+
+Reproduction:
+```bash
+docpull http://example.com --single
+echo $?
+docpull https://localhost --single
+echo $?
+```
+
+Expected: security-policy rejections should be machine-visible failures for agent/CI callers, at least in `--single` mode.  
+Actual: exit code 0.  
+Resolution: `--single` now returns nonzero for URL-validation and robots-policy skips.
+
+### P2 - Resolved: `--insecure-tls` help advertised unsupported behavior
+
+Severity: Medium  
+Confidence: High  
+Evidence:
+- `docpull --help` says `--insecure-tls Disable TLS certificate verification (unsafe)`.
+- `src/docpull/cli.py:466-471` immediately rejects it.
+- `src/docpull/models/config.py:293-298`, `src/docpull/http/client.py:159-160`, and `src/docpull/security/robots.py:124-125` reject insecure TLS.
+
+Reproduction:
+```bash
+docpull https://example.com --single --insecure-tls
+```
+
+Expected: help says the flag is deprecated/rejected or the flag is removed.  
+Actual: help says it disables TLS verification, then command exits 1.  
+Resolution: help text now states the flag is deprecated and rejected.
+
+### P2 - Resolved: plugin README cache path was wrong for Python MCP
+
+Severity: Medium  
+Confidence: High  
+Evidence:
+- `plugin/README.md:63-65` says fetched docs live under `$XDG_DATA_HOME/docpull/docs` / `~/.local/share/docpull/docs`.
+- Python MCP source defaults use `docpull-mcp/docs` (`src/docpull/mcp/sources.py` via `default_docs_dir()`; observed in code inspection).
+
+Reproduction:
+1. Read `plugin/README.md`.
+2. Inspect `src/docpull/mcp/sources.py`.
+
+Expected: plugin docs match actual MCP cache path.  
+Actual: docs point users to a different directory.  
+Resolution: plugin README now documents `docpull-mcp/docs`.
+
+### P2 - Resolved: product/site "fail-loud" wording conflicted with LLM profile default
+
+Severity: Low to Medium  
+Confidence: High  
+Evidence:
+- Live site says LLM is "fail-loud on JS-only pages".
+- `src/docpull/models/profiles.py:54-57` sets `strict_js_required=False`.
+
+Reproduction:
+1. Inspect product-site rendered HTML or `web` source.
+2. Inspect `ProfileName.LLM` defaults.
+
+Expected: product copy matches default profile behavior.  
+Actual: strict JS failure requires `--strict-js-required`; LLM profile skips by default.  
+Resolution: web profile copy now says LLM skips JS-only pages unless strict mode is enabled.
+
+### P2 - Resolved: Crawl-delay was discoverable but not clearly enforced
+
+Severity: Low  
+Confidence: Medium  
+Evidence:
+- `RobotsChecker.get_crawl_delay()` exists in `src/docpull/security/robots.py:337-361`.
+- No inspected path showed it being applied to `PerHostRateLimiter` or crawl scheduling.
+
+Reproduction:
+1. Add a fixture robots.txt with `Crawl-delay`.
+2. Crawl two pages and measure inter-request timing.
+
+Expected: if crawl-delay is a claimed behavior, requests honor it.  
+Actual: unverified; implementation path not obvious.  
+Resolution: `Fetcher._apply_robots_crawl_delay()` now wires robots `Crawl-delay` into the start host's rate limiter and tests cover both robots-slower and user-slower cases.
+
+## Implementation Plan
+
+1. Docs/package alignment patch:
+- Fix local `mcp/README.md` and `mcp/package.json` mirror references.
+- Fix plugin README cache path and version prerequisite.
+- Fix `--insecure-tls` help.
+- Fix LLM fail-loud wording.
+- Fix mirror profile wording or behavior.
+
+2. CLI correctness patch:
+- Make `--single` security validation failures return nonzero.
+- Add tests for unsafe URL exit codes, `--insecure-tls`, and proxy + `--require-pinned-dns`.
+- Add a smoke test matrix for `--version`, `--help`, `--doctor`, `docpull mcp --help`.
+
+3. Profile/output contract patch:
+- Decide mirror naming semantics and lock with tests.
+- Add profile-default tests that assert `rag`, `llm`, `mirror`, `quick` config expansions.
+- Add manifest schema snapshot tests for all formats.
+
+4. Security hardening follow-up:
+- Run `bandit -c pyproject.toml -r src/docpull` in CI/docs instead of raw command.
+- Add tests for crawl-delay if claimed, symlinked output/cache directories, decompression/content-size behavior, and malformed metadata/frontmatter injection.
+
+5. Product expansion:
+- Make Python MCP the default public MCP path and label root TS MCP as experimental/private until the repository and install path are real.
+- Add optional SQLite FTS for local search before committing to pgvector/OpenAI semantic search as the main path.
+- Add verified framework fixtures for Sphinx, MkDocs, VitePress, Starlight, GitBook, ReadMe.io, Redoc, Scalar.
+- Add auth-gated docs mode with host allowlists, credential scoping, secret redaction, and audit logs.
+- Consider an optional JS renderer adapter behind an explicit extra and policy gate; keep browser-free default.
+
+## Audit Bottom Line
+
+DocPull 4.0.0 is locally runnable and substantially better than the stale untracked audit notes suggest. The Python package clears the main gates and has meaningful security architecture. The next highest-leverage work is not a rewrite; it is tightening public claims, release metadata, and agent-facing failure semantics so the project presents the same contract across README, PyPI, website, CLI, MCP, plugin, and code.

--- a/audit/2026-06-06-current-audit.md
+++ b/audit/2026-06-06-current-audit.md
@@ -204,8 +204,8 @@ Not exhaustively rerun in this pass:
 
 ### P1 - Resolved Locally: public PyPI README still claims a `docpull-mcp` mirror that returns 404
 
-Severity: High  
-Confidence: High  
+Severity: High
+Confidence: High
 Evidence:
 - PyPI project page for `4.0.0` says the root `mcp/` tree is mirrored to `raintree-technology/docpull-mcp`.
 - `curl -I -L https://github.com/raintree-technology/docpull-mcp` returned HTTP 404.
@@ -218,14 +218,14 @@ Reproduction:
 2. Search for `docpull-mcp`.
 3. Open `https://github.com/raintree-technology/docpull-mcp`.
 
-Expected: linked mirror exists, or docs clearly say the mirror is private/unavailable.  
-Actual: public package metadata points users to a 404.  
+Expected: linked mirror exists, or docs clearly say the mirror is private/unavailable.
+Actual: public package metadata points users to a 404.
 Resolution: local `mcp/README.md` and `mcp/package.json` now point to the in-repo `mcp/` directory under the main `docpull` repository. A package release is still needed to replace the older PyPI long description.
 
 ### P1 - Resolved: mirror profile naming claim was false
 
-Severity: Medium  
-Confidence: High  
+Severity: Medium
+Confidence: High
 Evidence:
 - CLI help says mirror profile defaults to hierarchical naming.
 - `src/docpull/models/profiles.py:22-38` intentionally does not set `output.naming_strategy`.
@@ -240,14 +240,14 @@ print(Fetcher(DocpullConfig(url="https://example.com", profile=ProfileName.MIRRO
 PY
 ```
 
-Expected: either `hierarchical` or docs do not claim mirror defaults hierarchical.  
-Actual: `full`.  
+Expected: either `hierarchical` or docs do not claim mirror defaults hierarchical.
+Actual: `full`.
 Resolution: mirror now defaults to hierarchical output paths, with a regression test proving explicit `full` overrides still win.
 
 ### P1 - Resolved: security validation skips returned exit code 0 in `--single`
 
-Severity: Medium  
-Confidence: High  
+Severity: Medium
+Confidence: High
 Evidence:
 - `docpull http://example.com --single` exits 0 with `Skipped: URL validation failed: Scheme 'http' not allowed`.
 - `docpull https://localhost --single` exits 0 with `Skipped: URL validation failed: Localhost URLs not allowed`.
@@ -261,14 +261,14 @@ docpull https://localhost --single
 echo $?
 ```
 
-Expected: security-policy rejections should be machine-visible failures for agent/CI callers, at least in `--single` mode.  
-Actual: exit code 0.  
+Expected: security-policy rejections should be machine-visible failures for agent/CI callers, at least in `--single` mode.
+Actual: exit code 0.
 Resolution: `--single` now returns nonzero for URL-validation and robots-policy skips.
 
 ### P2 - Resolved: `--insecure-tls` help advertised unsupported behavior
 
-Severity: Medium  
-Confidence: High  
+Severity: Medium
+Confidence: High
 Evidence:
 - `docpull --help` says `--insecure-tls Disable TLS certificate verification (unsafe)`.
 - `src/docpull/cli.py:466-471` immediately rejects it.
@@ -279,14 +279,14 @@ Reproduction:
 docpull https://example.com --single --insecure-tls
 ```
 
-Expected: help says the flag is deprecated/rejected or the flag is removed.  
-Actual: help says it disables TLS verification, then command exits 1.  
+Expected: help says the flag is deprecated/rejected or the flag is removed.
+Actual: help says it disables TLS verification, then command exits 1.
 Resolution: help text now states the flag is deprecated and rejected.
 
 ### P2 - Resolved: plugin README cache path was wrong for Python MCP
 
-Severity: Medium  
-Confidence: High  
+Severity: Medium
+Confidence: High
 Evidence:
 - `plugin/README.md:63-65` says fetched docs live under `$XDG_DATA_HOME/docpull/docs` / `~/.local/share/docpull/docs`.
 - Python MCP source defaults use `docpull-mcp/docs` (`src/docpull/mcp/sources.py` via `default_docs_dir()`; observed in code inspection).
@@ -295,14 +295,14 @@ Reproduction:
 1. Read `plugin/README.md`.
 2. Inspect `src/docpull/mcp/sources.py`.
 
-Expected: plugin docs match actual MCP cache path.  
-Actual: docs point users to a different directory.  
+Expected: plugin docs match actual MCP cache path.
+Actual: docs point users to a different directory.
 Resolution: plugin README now documents `docpull-mcp/docs`.
 
 ### P2 - Resolved: product/site "fail-loud" wording conflicted with LLM profile default
 
-Severity: Low to Medium  
-Confidence: High  
+Severity: Low to Medium
+Confidence: High
 Evidence:
 - Live site says LLM is "fail-loud on JS-only pages".
 - `src/docpull/models/profiles.py:54-57` sets `strict_js_required=False`.
@@ -311,14 +311,14 @@ Reproduction:
 1. Inspect product-site rendered HTML or `web` source.
 2. Inspect `ProfileName.LLM` defaults.
 
-Expected: product copy matches default profile behavior.  
-Actual: strict JS failure requires `--strict-js-required`; LLM profile skips by default.  
+Expected: product copy matches default profile behavior.
+Actual: strict JS failure requires `--strict-js-required`; LLM profile skips by default.
 Resolution: web profile copy now says LLM skips JS-only pages unless strict mode is enabled.
 
 ### P2 - Resolved: Crawl-delay was discoverable but not clearly enforced
 
-Severity: Low  
-Confidence: Medium  
+Severity: Low
+Confidence: Medium
 Evidence:
 - `RobotsChecker.get_crawl_delay()` exists in `src/docpull/security/robots.py:337-361`.
 - No inspected path showed it being applied to `PerHostRateLimiter` or crawl scheduling.
@@ -327,8 +327,8 @@ Reproduction:
 1. Add a fixture robots.txt with `Crawl-delay`.
 2. Crawl two pages and measure inter-request timing.
 
-Expected: if crawl-delay is a claimed behavior, requests honor it.  
-Actual: unverified; implementation path not obvious.  
+Expected: if crawl-delay is a claimed behavior, requests honor it.
+Actual: unverified; implementation path not obvious.
 Resolution: `Fetcher._apply_robots_crawl_delay()` now wires robots `Crawl-delay` into the start host's rate limiter and tests cover both robots-slower and user-slower cases.
 
 ## Implementation Plan

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,8 +14,7 @@ MCP server for fetching and searching documentation on-demand. Uses [docpull](ht
 ## Install
 
 ```bash
-git clone https://github.com/raintree-technology/docpull-mcp
-cd docpull-mcp
+cd mcp
 bun install
 
 # Requires docpull CLI
@@ -56,7 +55,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "docpull": {
       "command": "bun",
-      "args": ["run", "/path/to/docpull-mcp/src/server.ts"],
+      "args": ["run", "/path/to/docpull/mcp/src/server.ts"],
       "env": {
         "DATABASE_URL": "postgresql://...",
         "OPENAI_API_KEY": "sk-..."
@@ -75,7 +74,7 @@ Add to `~/.claude/settings.json`:
   "mcpServers": {
     "docpull": {
       "command": "bun",
-      "args": ["run", "/path/to/docpull-mcp/src/server.ts"],
+      "args": ["run", "/path/to/docpull/mcp/src/server.ts"],
       "env": {
         "DATABASE_URL": "postgresql://...",
         "OPENAI_API_KEY": "sk-..."

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -34,7 +34,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/raintree-technology/docpull-mcp.git"
+		"url": "git+https://github.com/raintree-technology/docpull.git",
+		"directory": "mcp"
 	},
 	"license": "MIT",
 	"author": "Raintree Technology",

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -393,7 +393,7 @@ async function runDocpull(
 // MCP SERVER
 // ============================================================================
 
-const server = new McpServer({ name: "docpull-mcp", version: "0.2.0" });
+const server = new McpServer({ name: "docpull-mcp", version: "0.3.0" });
 
 // ---------------------------------------------------------------------------
 // ensure_docs - fetch and optionally index documentation

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -24,7 +24,7 @@ MCP server is available:
 ```bash
 pip install 'docpull[mcp]'          # or: pipx install 'docpull[mcp]'
                                     #     uv tool install 'docpull[mcp]'
-docpull --version                   # should print 2.5.0 or newer
+docpull --version                   # should print 4.0.0 or newer
 docpull mcp --help                  # confirm the MCP subcommand is wired
 ```
 
@@ -62,7 +62,7 @@ For anything else, pass an HTTPS URL: `/docs-add https://docs.your-library.com`.
 
 ## Where docs are cached
 
-By default, fetched docs live under `$XDG_DATA_HOME/docpull/docs/` (or `~/.local/share/docpull/docs/` on macOS/Linux). Override with `DOCPULL_DOCS_DIR` if you want them somewhere else (e.g. one cache per project).
+By default, fetched docs live under `$XDG_DATA_HOME/docpull-mcp/docs/` (or `~/.local/share/docpull-mcp/docs/` on macOS/Linux). Override with `DOCPULL_DOCS_DIR` if you want them somewhere else (e.g. one cache per project).
 
 ## Privacy
 

--- a/src/docpull/cli.py
+++ b/src/docpull/cli.py
@@ -139,7 +139,7 @@ Examples:
         help=(
             "URL-to-filename strategy. 'full' flattens with underscores; "
             "'hierarchical' preserves the URL path as nested directories. "
-            "Mirror profile defaults to hierarchical."
+            "Mirror profile defaults to hierarchical unless explicitly overridden."
         ),
     )
     parser.add_argument(
@@ -264,7 +264,7 @@ Examples:
     network_group.add_argument(
         "--insecure-tls",
         action="store_true",
-        help="Disable TLS certificate verification (unsafe)",
+        help="Deprecated and rejected; docpull always verifies TLS certificates",
     )
     network_group.add_argument(
         "--max-retries",
@@ -555,7 +555,11 @@ def run_fetcher(args: argparse.Namespace) -> int:
                         return 1
                     if ctx.should_skip:
                         console.print(f"[yellow]Skipped:[/yellow] {ctx.skip_reason}")
-                        return 0
+                        failure_skips = {
+                            SkipReason.URL_VALIDATION_FAILED,
+                            SkipReason.ROBOTS_DISALLOWED,
+                        }
+                        return 1 if ctx.skip_code in failure_skips else 0
                     if not args.quiet:
                         n_chunks = len(ctx.chunks) if ctx.chunks else 0
                         extra = f" ({n_chunks} chunks)" if n_chunks else ""

--- a/src/docpull/cli.py
+++ b/src/docpull/cli.py
@@ -134,7 +134,7 @@ Examples:
     )
     parser.add_argument(
         "--naming-strategy",
-        choices=["full", "hierarchical", "flat", "short"],
+        choices=["full", "hierarchical"],
         default=None,
         help=(
             "URL-to-filename strategy. 'full' flattens with underscores; "

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -40,8 +40,8 @@ def _url_to_filename(url: str, base_url: str | None = None) -> str:
     """
     Convert URL to a safe flattened filename (e.g. ``api_auth_oauth2.md``).
 
-    Used by the ``full`` / ``flat`` / ``short`` naming strategies. For the
-    ``hierarchical`` strategy, see :func:`_url_to_path_parts`.
+    Used by the ``full`` naming strategy. For the ``hierarchical`` strategy,
+    see :func:`_url_to_path_parts`.
 
     Args:
         url: The URL to convert
@@ -405,6 +405,7 @@ class Fetcher:
                 emit_chunks=self.config.output.emit_chunks,
                 skill_name=self.config.output.skill_name,
                 skill_description=self.config.output.skill_description,
+                run_identity=self.run_identity,
             )
             steps.append(self._save_step)
 

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -315,6 +315,7 @@ class Fetcher:
             url_validator=self._url_validator,
             allow_insecure_tls=self.config.network.insecure_tls,
         )
+        self._apply_robots_crawl_delay()
 
         # Build pipeline
         output_dir = self.config.output.directory.resolve()
@@ -447,6 +448,21 @@ class Fetcher:
         )
 
         return self
+
+    def _apply_robots_crawl_delay(self) -> None:
+        """Apply robots.txt Crawl-delay for the configured start host, if present."""
+        if self._robots_checker is None or self._rate_limiter is None or not self.config.url:
+            return
+        delay = self._robots_checker.get_crawl_delay(self.config.url)
+        if delay is None:
+            return
+        host = urlparse(self.config.url).netloc
+        if not host:
+            return
+        self._rate_limiter.update_host_config(
+            host,
+            delay=max(self.config.crawl.rate_limit, delay),
+        )
 
     async def __aexit__(
         self,

--- a/src/docpull/models/document.py
+++ b/src/docpull/models/document.py
@@ -15,6 +15,7 @@ class DocumentRecord(BaseModel):
     """Versioned logical document shape independent of output container."""
 
     schema_version: int = DOCUMENT_RECORD_SCHEMA_VERSION
+    document_id: str
     url: str
     title: str | None = None
     content: str
@@ -25,6 +26,7 @@ class DocumentRecord(BaseModel):
     content_hash: str
     run: dict[str, Any] | None = None
     chunk_index: int | None = None
+    chunk_id: str | None = None
     chunk_heading: str | None = None
     token_count: int | None = None
 
@@ -43,16 +45,34 @@ class DocumentRecord(BaseModel):
         chunk_heading: str | None = None,
         token_count: int | None = None,
     ) -> DocumentRecord:
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        document_id = _stable_id("doc", url, content_hash)
+        chunk_id = None
+        if chunk_index is not None:
+            chunk_id = _stable_id(
+                "chunk",
+                url,
+                str(chunk_index),
+                chunk_heading or "",
+                content_hash,
+            )
         return cls(
+            document_id=document_id,
             url=url,
             title=title,
             content=content,
             metadata=metadata or {},
             extraction=extraction or {},
             source_type=source_type,
-            content_hash=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            content_hash=content_hash,
             run=run_identity.model_dump(mode="json") if run_identity else None,
             chunk_index=chunk_index,
+            chunk_id=chunk_id,
             chunk_heading=chunk_heading,
             token_count=token_count,
         )
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:24]}"

--- a/src/docpull/models/profiles.py
+++ b/src/docpull/models/profiles.py
@@ -45,7 +45,7 @@ PROFILES: dict[ProfileName, dict[str, Any]] = {
         },
     },
     ProfileName.LLM: {
-        # Token-aware output, streaming NDJSON, fail-loud on JS-only pages.
+        # Token-aware output, streaming NDJSON, JS-only pages skipped by default.
         # This is what "AI-ready Markdown" should actually mean: predictable
         # chunk sizes, stable hashes, one-record-per-line streaming.
         "crawl": {

--- a/src/docpull/models/profiles.py
+++ b/src/docpull/models/profiles.py
@@ -20,16 +20,14 @@ PROFILES: dict[ProfileName, dict[str, Any]] = {
         },
     },
     ProfileName.MIRROR: {
-        # Full site mirror for offline archive.
-        #
-        # NOTE: hierarchical naming is intentionally NOT in this profile
-        # in 2.x to preserve existing users' output paths. They opt in via
-        # `--naming-strategy hierarchical` or `output.naming_strategy:
-        # hierarchical` in YAML. In 3.0 the Mirror default flips to
-        # hierarchical (per the SemVer plan).
+        # Full site mirror for offline archive. Preserve URL paths so the
+        # on-disk archive is navigable and stable for citation.
         "crawl": {
             "max_depth": 10,
             "max_concurrent": 5,  # Be polite
+        },
+        "output": {
+            "naming_strategy": "hierarchical",
         },
         "cache": {
             "enabled": True,

--- a/src/docpull/pipeline/manifest.py
+++ b/src/docpull/pipeline/manifest.py
@@ -1,0 +1,74 @@
+"""Corpus manifest support for output sinks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..models.document import DocumentRecord
+from ..models.run import RunIdentity
+from ..time_utils import utc_now_iso
+
+
+class CorpusManifest:
+    """Collect stable record metadata and write ``corpus.manifest.json``."""
+
+    def __init__(
+        self,
+        base_output_dir: Path,
+        *,
+        output_format: str,
+        run_identity: RunIdentity | None = None,
+        filename: str = "corpus.manifest.json",
+    ) -> None:
+        self._base_dir = base_output_dir.resolve()
+        self._path = self._base_dir / filename
+        self._output_format = output_format
+        self._run_identity = run_identity
+        self._records: list[dict[str, Any]] = []
+        self._seen: set[str] = set()
+
+    def add_record(self, record: DocumentRecord, output_path: Path | None = None) -> None:
+        record_key = record.chunk_id or record.document_id
+        if record_key in self._seen:
+            return
+        self._seen.add(record_key)
+        item: dict[str, Any] = {
+            "document_id": record.document_id,
+            "url": record.url,
+            "content_hash": record.content_hash,
+        }
+        if record.title is not None:
+            item["title"] = record.title
+        if record.source_type is not None:
+            item["source_type"] = record.source_type
+        if record.chunk_index is not None:
+            item["chunk_index"] = record.chunk_index
+        if record.chunk_id is not None:
+            item["chunk_id"] = record.chunk_id
+        if record.chunk_heading is not None:
+            item["chunk_heading"] = record.chunk_heading
+        if record.token_count is not None:
+            item["token_count"] = record.token_count
+        if output_path is not None:
+            try:
+                item["output_path"] = str(output_path.resolve().relative_to(self._base_dir))
+            except ValueError:
+                item["output_path"] = str(output_path)
+        self._records.append(item)
+
+    def finalize(self) -> Path:
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "generated_at": utc_now_iso(),
+            "output_format": self._output_format,
+            "run": self._run_identity.model_dump(mode="json") if self._run_identity else None,
+            "document_count": len({item["document_id"] for item in self._records}),
+            "record_count": len(self._records),
+            "chunk_count": sum(1 for item in self._records if "chunk_id" in item),
+            "records": self._records,
+        }
+        self._path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        return self._path

--- a/src/docpull/pipeline/steps/save.py
+++ b/src/docpull/pipeline/steps/save.py
@@ -4,8 +4,11 @@ import asyncio
 import logging
 from pathlib import Path
 
+from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent, SkipReason
+from ...models.run import RunIdentity
 from ..base import EventEmitter, PageContext
+from ..manifest import CorpusManifest
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +36,7 @@ class SaveStep:
         emit_chunks: bool = False,
         skill_name: str | None = None,
         skill_description: str | None = None,
+        run_identity: RunIdentity | None = None,
     ) -> None:
         """
         Initialize the save step.
@@ -55,6 +59,16 @@ class SaveStep:
         self._skill_description = skill_description
         self._first_metadata: dict[str, object] | None = None
         self._first_title: str | None = None
+        self._run_identity = run_identity
+        self._manifest = (
+            CorpusManifest(
+                base_output_dir,
+                output_format="markdown",
+                run_identity=run_identity,
+            )
+            if base_output_dir is not None
+            else None
+        )
 
     def _validate_output_path(self, output_path: Path) -> Path:
         """
@@ -138,6 +152,20 @@ class SaveStep:
                     text = getattr(chunk, "text", "")
                     chunk_path = parent / f"{stem}.{idx:0{width}d}{ext}"
                     await asyncio.to_thread(chunk_path.write_text, text, encoding="utf-8")
+                    if self._manifest is not None:
+                        record = DocumentRecord.from_page(
+                            url=ctx.url,
+                            title=ctx.title,
+                            content=text,
+                            metadata=ctx.metadata,
+                            extraction=ctx.extraction_info,
+                            source_type=ctx.source_type,
+                            run_identity=self._run_identity,
+                            chunk_index=idx,
+                            chunk_heading=getattr(chunk, "heading", None),
+                            token_count=getattr(chunk, "token_count", None),
+                        )
+                        self._manifest.add_record(record, chunk_path)
                     if first_chunk_path is None:
                         first_chunk_path = chunk_path
                 ctx.persisted_path = first_chunk_path
@@ -151,6 +179,17 @@ class SaveStep:
                 )
                 ctx.persisted_path = validated_path
                 logger.info(f"Saved: {validated_path}")
+                if self._manifest is not None:
+                    record = DocumentRecord.from_page(
+                        url=ctx.url,
+                        title=ctx.title,
+                        content=content,
+                        metadata=ctx.metadata,
+                        extraction=ctx.extraction_info,
+                        source_type=ctx.source_type,
+                        run_identity=self._run_identity,
+                    )
+                    self._manifest.add_record(record, validated_path)
 
             # Snapshot the first successful page's metadata for SKILL.md.
             if self._skill_name and self._first_metadata is None:
@@ -210,7 +249,11 @@ class SaveStep:
         re-written with the same content).
         """
         if not self._skill_name or self._base_output_dir is None:
+            if self._manifest is not None:
+                self._manifest.finalize()
             return
+        if self._manifest is not None:
+            self._manifest.finalize()
         manifest_path = self._base_output_dir / "SKILL.md"
         description = self._skill_description or self._derive_description()
         body = self._render_skill_manifest(description)

--- a/src/docpull/pipeline/steps/save_json.py
+++ b/src/docpull/pipeline/steps/save_json.py
@@ -15,6 +15,7 @@ from ...models.events import EventType, FetchEvent
 from ...models.run import RunIdentity
 from ...time_utils import utc_now_iso
 from ..base import EventEmitter, PageContext
+from ..manifest import CorpusManifest
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,11 @@ class JsonSaveStep:
         self._temp_path: str | None = None
         self._first_doc = True
         self._run_identity = run_identity
+        self._manifest = CorpusManifest(
+            self._base_dir,
+            output_format="json",
+            run_identity=run_identity,
+        )
 
     def _ensure_temp_file(self) -> TextIO:
         """Create temp file for streaming writes if not already open."""
@@ -111,6 +117,7 @@ class JsonSaveStep:
             run_identity=self._run_identity,
         )
         doc = record.model_dump(mode="json", exclude_none=True)
+        self._manifest.add_record(record, self._output_file)
 
         f = self._ensure_temp_file()
 
@@ -158,6 +165,7 @@ class JsonSaveStep:
             }
             with open(self._output_file, "w", encoding="utf-8") as f:
                 json.dump(output, f, indent=2, ensure_ascii=False)
+            self._manifest.finalize()
             logger.info(f"Saved 0 documents to {self._output_file}")
             return self._output_file
 
@@ -178,6 +186,7 @@ class JsonSaveStep:
             if self._temp_path is None:
                 raise RuntimeError("Temporary JSON output path was not initialized")
             os.replace(self._temp_path, self._output_file)
+            self._manifest.finalize()
             logger.info(f"Saved {self._document_count} documents to {self._output_file}")
 
         except Exception:

--- a/src/docpull/pipeline/steps/save_ndjson.py
+++ b/src/docpull/pipeline/steps/save_ndjson.py
@@ -18,6 +18,7 @@ from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent
 from ...models.run import RunIdentity
 from ..base import EventEmitter, PageContext
+from ..manifest import CorpusManifest
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,11 @@ class NdjsonSaveStep:
         self._output_path: Path | None = None
         self._lock = asyncio.Lock()
         self._run_identity = run_identity
+        self._manifest = CorpusManifest(
+            self._base_dir,
+            output_format="ndjson",
+            run_identity=run_identity,
+        )
 
     def _ensure_open(self) -> IO[str]:
         if self._fp is not None:
@@ -92,6 +98,7 @@ class NdjsonSaveStep:
                         chunk_heading=getattr(chunk, "heading", None),
                         token_count=getattr(chunk, "token_count", None),
                     )
+                    self._manifest.add_record(record, self._output_path)
                     self._write_record(record.model_dump(mode="json", exclude_none=True))
                     self._chunk_count += 1
             else:
@@ -104,6 +111,7 @@ class NdjsonSaveStep:
                     source_type=ctx.source_type,
                     run_identity=self._run_identity,
                 )
+                self._manifest.add_record(record, self._output_path)
                 self._write_record(record.model_dump(mode="json", exclude_none=True))
             self._document_count += 1
             ctx.persisted_path = self._output_path
@@ -126,6 +134,7 @@ class NdjsonSaveStep:
             except Exception as err:  # noqa: BLE001
                 logger.warning("Error closing NDJSON file: %s", err)
         self._fp = None
+        self._manifest.finalize()
         if self._output_path:
             logger.info(
                 "Wrote %d records (%d chunks) to %s",

--- a/src/docpull/pipeline/steps/save_sqlite.py
+++ b/src/docpull/pipeline/steps/save_sqlite.py
@@ -11,6 +11,7 @@ from ...models.document import DocumentRecord
 from ...models.events import EventType, FetchEvent
 from ...models.run import RunIdentity
 from ..base import EventEmitter, PageContext
+from ..manifest import CorpusManifest
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,11 @@ class SqliteSaveStep:
         self._document_count = 0
         self._pending_count = 0  # Track uncommitted documents
         self._run_identity = run_identity
+        self._manifest = CorpusManifest(
+            self._base_dir,
+            output_format="sqlite",
+            run_identity=run_identity,
+        )
 
     def _ensure_db(self) -> sqlite3.Connection:
         """Ensure the database and table exist."""
@@ -166,6 +172,7 @@ class SqliteSaveStep:
             if cursor.rowcount > 0:
                 self._document_count += 1
                 self._pending_count += 1
+                self._manifest.add_record(record, self._db_path)
 
             # Batch commits for performance
             if self._pending_count >= self.BATCH_SIZE:
@@ -205,6 +212,7 @@ class SqliteSaveStep:
             if self._pending_count > 0:
                 self._conn.commit()
                 self._pending_count = 0
+            self._manifest.finalize()
             self._conn.close()
             self._conn = None
             logger.info(f"Closed SQLite database with {self._document_count} documents")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,9 +33,7 @@ def test_parser_accepts_supported_naming_strategies():
     parser = create_parser()
 
     full = parser.parse_args(["https://example.com", "--naming-strategy", "full"])
-    hierarchical = parser.parse_args(
-        ["https://example.com", "--naming-strategy", "hierarchical"]
-    )
+    hierarchical = parser.parse_args(["https://example.com", "--naming-strategy", "hierarchical"])
 
     assert full.naming_strategy == "full"
     assert hierarchical.naming_strategy == "hierarchical"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,3 +18,24 @@ def test_parser_rejects_removed_js_flag():
 
     with pytest.raises(SystemExit):
         parser.parse_args(["https://example.com", "--js"])
+
+
+@pytest.mark.parametrize("alias", ["flat", "short"])
+def test_parser_rejects_removed_naming_aliases(alias: str):
+    """Ensure removed naming aliases stay unavailable at the CLI boundary."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["https://example.com", "--naming-strategy", alias])
+
+
+def test_parser_accepts_supported_naming_strategies():
+    parser = create_parser()
+
+    full = parser.parse_args(["https://example.com", "--naming-strategy", "full"])
+    hierarchical = parser.parse_args(
+        ["https://example.com", "--naming-strategy", "hierarchical"]
+    )
+
+    assert full.naming_strategy == "full"
+    assert hierarchical.naming_strategy == "hierarchical"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 import pytest
 
 import docpull
-from docpull.cli import create_parser
+from docpull.cli import create_parser, run_fetcher
 
 
 def test_runtime_version_matches_package_metadata():
@@ -39,3 +39,23 @@ def test_parser_accepts_supported_naming_strategies():
 
     assert full.naming_strategy == "full"
     assert hierarchical.naming_strategy == "hierarchical"
+
+
+def test_help_describes_insecure_tls_as_rejected():
+    parser = create_parser()
+
+    assert "Deprecated and rejected" in parser.format_help()
+
+
+def test_help_describes_mirror_naming_override():
+    parser = create_parser()
+    help_text = " ".join(parser.format_help().split())
+
+    assert "Mirror profile defaults to hierarchical unless explicitly overridden" in help_text
+
+
+def test_single_invalid_url_returns_nonzero(tmp_path):
+    parser = create_parser()
+    args = parser.parse_args(["http://example.com", "--single", "--output-dir", str(tmp_path)])
+
+    assert run_fetcher(args) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,6 +81,59 @@ class TestDocpullConfig:
                 network={"insecure_tls": True},
             )
 
+    def test_fetcher_applies_robots_crawl_delay_to_rate_limiter(self):
+        """Robots Crawl-delay becomes a per-host limiter override."""
+
+        class FakeRobots:
+            def get_crawl_delay(self, url: str) -> float:
+                assert url == "https://example.com/docs"
+                return 2.0
+
+        class FakeRateLimiter:
+            def __init__(self):
+                self.calls: list[tuple[str, float | None]] = []
+
+            def update_host_config(
+                self, host: str, delay: float | None = None, concurrent: int | None = None
+            ):
+                self.calls.append((host, delay))
+
+        config = DocpullConfig(url="https://example.com/docs", crawl={"rate_limit": 0.5})
+        fetcher = Fetcher(config)
+        limiter = FakeRateLimiter()
+        fetcher._robots_checker = FakeRobots()  # type: ignore[assignment]
+        fetcher._rate_limiter = limiter  # type: ignore[assignment]
+
+        fetcher._apply_robots_crawl_delay()
+
+        assert limiter.calls == [("example.com", 2.0)]
+
+    def test_fetcher_keeps_stricter_user_rate_limit_over_crawl_delay(self):
+        """A faster Crawl-delay must not loosen an explicit slower rate limit."""
+
+        class FakeRobots:
+            def get_crawl_delay(self, url: str) -> float:
+                return 1.0
+
+        class FakeRateLimiter:
+            def __init__(self):
+                self.delay: float | None = None
+
+            def update_host_config(
+                self, host: str, delay: float | None = None, concurrent: int | None = None
+            ):
+                self.delay = delay
+
+        config = DocpullConfig(url="https://example.com/docs", crawl={"rate_limit": 3.0})
+        fetcher = Fetcher(config)
+        limiter = FakeRateLimiter()
+        fetcher._robots_checker = FakeRobots()  # type: ignore[assignment]
+        fetcher._rate_limiter = limiter  # type: ignore[assignment]
+
+        fetcher._apply_robots_crawl_delay()
+
+        assert limiter.delay == 3.0
+
     def test_config_dry_run(self):
         """Test config with dry run enabled."""
         config = DocpullConfig(url="https://example.com", dry_run=True)
@@ -308,6 +361,20 @@ class TestProfileDefaults:
         config = apply_profile(config)
         # Mirror profile should have no page limit
         assert config.crawl.max_pages is None
+        assert config.output.naming_strategy == "hierarchical"
+
+    def test_mirror_profile_respects_explicit_naming_strategy(self):
+        """Explicit output naming still wins over the mirror profile default."""
+        from docpull.models.profiles import apply_profile
+
+        config = DocpullConfig(
+            url="https://example.com",
+            profile=ProfileName.MIRROR,
+            output={"naming_strategy": "full"},
+        )
+        config = apply_profile(config)
+
+        assert config.output.naming_strategy == "full"
 
     def test_quick_profile_defaults(self):
         """Test quick profile applies correct defaults."""

--- a/tests/test_outputs_e2e.py
+++ b/tests/test_outputs_e2e.py
@@ -1,0 +1,120 @@
+"""Local end-to-end output format tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from docpull.core.fetcher import Fetcher
+from docpull.models.config import DocpullConfig
+from docpull.security.robots import RobotsChecker
+from docpull.security.url_validator import UrlValidator
+
+PAGE_HTML = b"""<!doctype html><html><head><title>Alpha Docs</title></head>
+<body><article><h1>Alpha</h1><p>First page for local e2e output tests.</p></article></body></html>"""
+
+
+@pytest.fixture
+async def output_server(monkeypatch: pytest.MonkeyPatch):
+    async def page(_request: web.Request) -> web.Response:
+        return web.Response(body=PAGE_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/docs/alpha", page)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+
+    def permissive_validate(self, hostname):  # type: ignore[no-untyped-def]
+        from docpull.security.url_validator import UrlValidationResult
+
+        return UrlValidationResult.valid()
+
+    original_init = UrlValidator.__init__
+
+    def init_with_http(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["allowed_schemes"] = {"http", "https"}
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(UrlValidator, "validate_hostname", permissive_validate)
+    monkeypatch.setattr(UrlValidator, "__init__", init_with_http)
+    monkeypatch.setattr(RobotsChecker, "is_allowed", lambda self, url: True)
+    monkeypatch.setattr(RobotsChecker, "get_sitemaps", lambda self, url: [])
+    monkeypatch.setattr(RobotsChecker, "get_crawl_delay", lambda self, url: None)
+
+    yield f"http://127.0.0.1:{port}/docs/alpha"
+
+    await runner.cleanup()
+
+
+async def _run_single(url: str, output_dir: Path, output: dict[str, object]) -> None:
+    cfg = DocpullConfig(
+        url=url,
+        output={"directory": output_dir, **output},
+        crawl={"max_pages": 1, "streaming_discovery": False},
+    )
+    async with Fetcher(cfg) as fetcher:
+        await fetcher.fetch_one(url)
+
+
+@pytest.mark.asyncio
+async def test_json_output_schema_local_server(output_server: str, tmp_path: Path) -> None:
+    await _run_single(output_server, tmp_path, {"format": "json"})
+
+    data = json.loads((tmp_path / "documents.json").read_text())
+    assert data["document_count"] == 1
+    record = data["documents"][0]
+    assert record["url"] == output_server
+    assert record["document_id"].startswith("doc_")
+    assert record["content_hash"]
+
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
+    assert manifest["output_format"] == "json"
+    assert manifest["document_count"] == 1
+    assert manifest["records"][0]["document_id"] == record["document_id"]
+
+
+@pytest.mark.asyncio
+async def test_ndjson_chunk_output_local_server(output_server: str, tmp_path: Path) -> None:
+    await _run_single(
+        output_server,
+        tmp_path,
+        {
+            "format": "ndjson",
+            "emit_chunks": True,
+            "max_tokens_per_file": 100,
+            "ndjson_filename": "docs.ndjson",
+        },
+    )
+
+    lines = [json.loads(line) for line in (tmp_path / "docs.ndjson").read_text().splitlines()]
+    assert lines
+    assert all(line["chunk_id"].startswith("chunk_") for line in lines)
+
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
+    assert manifest["output_format"] == "ndjson"
+    assert manifest["chunk_count"] == len(lines)
+    assert manifest["records"][0]["chunk_id"] == lines[0]["chunk_id"]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_output_schema_local_server(output_server: str, tmp_path: Path) -> None:
+    await _run_single(output_server, tmp_path, {"format": "sqlite"})
+
+    conn = sqlite3.connect(tmp_path / "documents.db")
+    try:
+        row = conn.execute("SELECT url, content_hash FROM documents").fetchone()
+    finally:
+        conn.close()
+    assert row == (output_server, row[1])
+    assert row[1]
+
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
+    assert manifest["output_format"] == "sqlite"
+    assert manifest["record_count"] == 1

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -10,6 +11,8 @@ import pytest
 from pydantic import ValidationError
 
 from docpull.http.client import AsyncHttpClient, _ValidatedResolver
+from docpull.pipeline.base import PageContext
+from docpull.pipeline.steps.save import SaveStep
 from docpull.security.robots import RobotsChecker, _RobotsResponse
 from docpull.security.url_validator import UrlValidationResult, UrlValidator
 
@@ -224,6 +227,25 @@ class TestRedirectValidation:
         assert validator.validate.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_redirect_to_ipv4_mapped_private_ipv6_blocked(self) -> None:
+        client = AsyncHttpClient(
+            rate_limiter=_DummyRateLimiter(),
+            url_validator=UrlValidator(),
+        )
+        client._session = _FakeSession(
+            [
+                _FakeResponse(
+                    302,
+                    headers={"Location": "https://[::ffff:127.0.0.1]/admin"},
+                    url="https://public.example/start",
+                )
+            ]
+        )
+
+        with pytest.raises(ValueError, match="URL validation failed"):
+            await client.get("https://public.example/start")
+
+    @pytest.mark.asyncio
     async def test_http_client_strips_auth_headers_for_off_scope_requests(self) -> None:
         client = AsyncHttpClient(
             rate_limiter=_DummyRateLimiter(),
@@ -357,6 +379,46 @@ class TestRedirectValidation:
 
         with pytest.raises(ValueError, match="exceeds maximum size"):
             checker._fetch_url("https://evil.example.com/robots.txt")
+
+    @pytest.mark.asyncio
+    async def test_http_client_caps_streamed_body_size(self) -> None:
+        client = AsyncHttpClient(
+            rate_limiter=_DummyRateLimiter(),
+            max_content_size=4,
+            max_retries=0,
+        )
+        client._session = _FakeSession(
+            [
+                _FakeResponse(
+                    200,
+                    headers={"Content-Type": "text/html"},
+                    chunks=[b"abc", b"def"],
+                    url="https://public.example/page",
+                )
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Content size limit exceeded"):
+            await client.get("https://public.example/page")
+
+    @pytest.mark.asyncio
+    async def test_save_step_rejects_symlink_escape(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        output = tmp_path / "out"
+        output.mkdir()
+        link = output / "linked"
+        link.symlink_to(outside, target_is_directory=True)
+
+        step = SaveStep(base_output_dir=output)
+        ctx = PageContext(
+            url="https://example.com/page",
+            output_path=link / "page.md",
+            markdown="# Page\n\nBody",
+        )
+
+        with pytest.raises(ValueError, match="outside base directory"):
+            await step.execute(ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/web/components/Profiles.tsx
+++ b/web/components/Profiles.tsx
@@ -6,7 +6,7 @@ const profiles = [
   },
   {
     name: "Mirror",
-    description: "Full archive with caching and resume support.",
+    description: "Full archive with caching, resume support, and hierarchical paths.",
     example: "docpull URL --profile mirror",
   },
   {
@@ -17,7 +17,7 @@ const profiles = [
   {
     name: "LLM",
     description:
-      "Token-aware NDJSON for LLM ingestion: chunked, deduped, fail-loud on JS-only pages.",
+      "Token-aware NDJSON for LLM ingestion: chunked, deduped, skips JS-only pages unless strict mode is enabled.",
     example: "docpull URL --profile llm --stream | jq .",
   },
 ];


### PR DESCRIPTION
## Summary
- Add the release accuracy audit artifacts and plugin bundle
- Align docs and web copy with current behavior
- Add tests and implementation fixes for mirror naming, rejected TLS opt-out, single invalid URL exit status, and robots Crawl-delay handling

## Validation
- Local validation was run on the repaired release branch earlier: Python tests, lint/typecheck/security, and web lint/typecheck/build passed.