### PR TITLE
Deepen Raindrop benchmark tracing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,7 +92,7 @@ jobs:
             TRACE_ARGS=(--trace raindrop)
           fi
           PYTHONPATH=src python -m docpull benchmark quick \
-            --target-set v2 \
+            --target-set provider-matrix \
             --provider all \
             --max-pages 8 \
             --max-depth 1 \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "benchmark-quick - run small real-site benchmark without live providers"
 	@echo "benchmark-parallel - run real-site benchmark with Parallel under cost guard"
 	@echo "benchmark-compare - run real-site benchmark with all configured providers"
-	@echo "benchmark-matrix - run v2 target-matrix benchmark with all configured providers"
+	@echo "benchmark-matrix - run provider target-matrix benchmark with all configured providers"
 	@echo "benchmark-raindrop - run real-site benchmark with all configured providers and Raindrop tracing"
 	@echo "lint - check style with ruff"
 	@echo "format - format code with ruff"
@@ -62,12 +62,12 @@ benchmark-compare:
 	$(PYTHON) -m docpull benchmark quick --provider all --max-estimated-cost 0.10
 
 benchmark-matrix:
-	$(PYTHON) -m docpull benchmark quick --target-set v2 --provider all \
+	$(PYTHON) -m docpull benchmark quick --target-set provider-matrix --provider all \
 		--max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
 		--max-estimated-cost 0.10
 
 benchmark-raindrop:
-	$(PYTHON) -m docpull benchmark quick --target-set v2 --provider all --trace raindrop \
+	$(PYTHON) -m docpull benchmark quick --target-set provider-matrix --provider all --trace raindrop \
 		--max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
 		--max-estimated-cost 0.10
 

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ benchmark harness:
 docpull benchmark quick
 docpull benchmark quick --provider auto --max-estimated-cost 0.05
 docpull benchmark quick --provider all --max-estimated-cost 0.10
-docpull benchmark quick --target-set v2 --provider all \
+docpull benchmark quick --target-set provider-matrix --provider all \
   --max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
   --max-estimated-cost 0.10
 docpull benchmark article .bench/runs/<run>/benchmark.report.json
@@ -504,7 +504,7 @@ Tavily, and Exa, then records missing keys or optional SDKs in
 the local `--max-estimated-cost` guard before any work starts.
 
 Use `--target-set tool-docs` to run a cross-pull matrix across the Parallel,
-Exa, Tavily, Raindrop, and DocPull documentation sites. Use `--target-set v2`
+Exa, Tavily, Raindrop, and DocPull documentation sites. Use `--target-set provider-matrix`
 to add three low-cap adversarial public targets for JS-heavy docs, noisy
 archived navigation, and freshness-sensitive pricing. Matrix runs skip the
 cached core pass by default so the headline grid stays provider x target; pass
@@ -536,7 +536,7 @@ export TAVILY_API_KEY="<your-tavily-api-key>"
 export TAVILY_CREDIT_USD="<account-credit-value>"
 export EXA_API_KEY="<your-exa-api-key>"
 export RAINDROP_WRITE_KEY="<your-raindrop-write-key>"
-docpull benchmark quick --target-set v2 --provider all --trace raindrop \
+docpull benchmark quick --target-set provider-matrix --provider all --trace raindrop \
   --max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
   --max-estimated-cost 0.10
 docpull benchmark article .bench/runs/<run>/benchmark.report.json
@@ -547,6 +547,11 @@ scores, costs, selected URLs, provider, workflow, target, prompt, settings, and
 artifact paths, but does not send scraped page content unless a future caller
 explicitly adds that behavior. `RAINDROP_WRITE_KEY` can be exported or stored in
 the same `~/.config/docpull/secrets.env` file as the provider keys.
+
+When Raindrop tracing is enabled, DocPull also emits Raindrop signals for
+attention-worthy benchmark cells: failed cases, low scores, slow cases,
+high-cost cells, and score-dimension warnings. The benchmark report stores the
+Raindrop event id and signal counts so traced runs can be audited later.
 
 ## Troubleshooting
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-06-08
+
 ### Added
 - Add `docpull benchmark quick` for repeatable real-site benchmark reports that
   compare core docpull crawls, cached reruns, and optional live Parallel Search
@@ -16,11 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   artifact links.
 - Add optional `docpull[observability]` Raindrop support so benchmark cases can
   be emitted as metadata-only traces when `RAINDROP_WRITE_KEY` is configured.
+- Add Raindrop event ids and per-case signals for benchmark failures, low
+  scores, high-score cells, high-cost cells, and score-dimension warnings.
 - Add Tavily and Exa live benchmark cases that normalize provider results into
   the same scored context-pack artifacts as core docpull and Parallel.
-- Add `docpull benchmark quick --target-set tool-docs/v2` for provider-by-target
-  matrix evals across Parallel, Exa, Tavily, Raindrop, DocPull, and low-cap
-  adversarial public targets.
+- Add `docpull benchmark quick --target-set tool-docs/provider-matrix` for
+  provider-by-target matrix evals across Parallel, Exa, Tavily, Raindrop,
+  DocPull, and low-cap adversarial public targets. The old `v2` target-set name
+  remains a compatibility alias.
 - Add weighted benchmark sub-scores for coverage, cleanliness, source fidelity,
   freshness, and density so clean and noisy targets no longer collapse to the
   same headline score.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "4.1.0"
+version = "4.2.0"
 dynamic = []
 description = "Pull documentation from the web and convert to clean markdown"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .conversion.chunking import Chunk, TokenCounter, chunk_markdown

--- a/src/docpull/benchmark.py
+++ b/src/docpull/benchmark.py
@@ -8,6 +8,7 @@ import json
 import resource
 import sys
 import time
+import uuid
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,7 +67,7 @@ BENCHMARK_SCORE_WEIGHTS = {
     "freshness": 0.15,
     "density": 0.15,
 }
-TARGET_SET_CHOICES = ("single", "tool-docs", "v2")
+TARGET_SET_CHOICES = ("single", "tool-docs", "provider-matrix", "v2")
 
 
 class BenchmarkError(RuntimeError):
@@ -201,6 +202,7 @@ ADVERSARIAL_TARGETS: tuple[_BenchmarkTarget, ...] = (
 
 TARGET_SETS: dict[str, tuple[_BenchmarkTarget, ...]] = {
     "tool-docs": TOOL_DOC_TARGETS,
+    "provider-matrix": (*TOOL_DOC_TARGETS, *ADVERSARIAL_TARGETS),
     "v2": (*TOOL_DOC_TARGETS, *ADVERSARIAL_TARGETS),
 }
 
@@ -224,16 +226,17 @@ def create_benchmark_parser() -> argparse.ArgumentParser:
         default=DEFAULT_TARGET_SET,
         help=(
             "Target matrix to run. 'single' preserves --target-url behavior; "
-            "'tool-docs' runs the five provider/docpull docs sites; 'v2' adds "
-            "low-cap adversarial targets."
+            "'tool-docs' runs the five provider/docpull docs sites; "
+            "'provider-matrix' adds low-cap hard targets. 'v2' remains as a "
+            "compatibility alias."
         ),
     )
     quick.add_argument(
         "--matrix",
         action="store_const",
-        const="v2",
+        const="provider-matrix",
         dest="target_set",
-        help="Compatibility alias for --target-set v2",
+        help="Compatibility alias for --target-set provider-matrix",
     )
     quick.add_argument(
         "--output-dir",
@@ -438,6 +441,7 @@ def run_quick_benchmark(
     _validate_positive_int(extract_limit, "extract_limit")
     if max_estimated_cost < 0:
         raise BenchmarkError("max_estimated_cost cannot be negative.")
+    target_set = _canonical_target_set(target_set)
     tavily_credit_usd = _resolve_tavily_credit_usd(tavily_credit_usd)
     targets = _resolve_benchmark_targets(
         target_url=target_url,
@@ -779,6 +783,7 @@ def _resolve_benchmark_targets(
     objective: str | None,
     queries: list[str],
 ) -> list[_BenchmarkTarget]:
+    target_set = _canonical_target_set(target_set)
     if target_set == "single":
         return [
             _single_benchmark_target(
@@ -807,6 +812,10 @@ def _resolve_benchmark_targets(
             )
         )
     return targets
+
+
+def _canonical_target_set(target_set: str) -> str:
+    return "provider-matrix" if target_set == "v2" else target_set
 
 
 def _single_benchmark_target(
@@ -1038,9 +1047,19 @@ class _RaindropTraceRecorder(_TraceRecorder):
             raindrop.init(api_key, tracing_enabled=True, bypass_otel_for_tools=True)
         except TypeError:
             raindrop.init(api_key, tracing_enabled=True)
+        self._event_id = str(uuid.uuid4())
         self._interaction = raindrop.begin(
             user_id="docpull-benchmark",
             event="docpull_benchmark",
+            event_id=self._event_id,
+            properties={
+                "target_set": target_set,
+                "target_count": len(targets),
+                "output_dir": str(output_dir),
+                "parallel_enabled": parallel_enabled,
+                "max_estimated_cost_usd": max_estimated_cost,
+                "content_policy": "metadata_only",
+            },
             input=_json_trace_text(
                 {
                     "target_url": target_url,
@@ -1052,8 +1071,11 @@ class _RaindropTraceRecorder(_TraceRecorder):
                 }
             ),
         )
-        self._event_id = str(getattr(self._interaction, "event_id", "") or "")
         self._case_count = 0
+        self._signal_count = 0
+        self._positive_signal_count = 0
+        self._negative_signal_count = 0
+        self._signal_names: Counter[str] = Counter()
         self._status = "recording"
 
     def record_case(self, case: dict[str, Any]) -> None:
@@ -1079,13 +1101,42 @@ class _RaindropTraceRecorder(_TraceRecorder):
                 "estimated_cost_usd": case.get("estimated_cost_usd", 0.0),
             },
         )
+        for signal in _raindrop_case_signals(case):
+            self._raindrop.track_signal(
+                event_id=self._event_id,
+                name=signal["name"],
+                properties=signal["properties"],
+                sentiment=signal["sentiment"],
+            )
+            self._signal_count += 1
+            self._signal_names[str(signal["name"])] += 1
+            if signal["sentiment"] == "POSITIVE":
+                self._positive_signal_count += 1
+            else:
+                self._negative_signal_count += 1
 
     def finish(self, report: dict[str, Any]) -> None:
+        self._interaction.set_properties(
+            {
+                "summary": report.get("summary"),
+                "artifacts": report.get("artifacts"),
+                "signal_count": self._signal_count,
+                "positive_signal_count": self._positive_signal_count,
+                "negative_signal_count": self._negative_signal_count,
+                "signal_names": dict(self._signal_names),
+            }
+        )
         self._interaction.finish(
             output=_json_trace_text(
                 {
                     "summary": report.get("summary"),
                     "artifacts": report.get("artifacts"),
+                    "trace_signals": {
+                        "total": self._signal_count,
+                        "positive": self._positive_signal_count,
+                        "negative": self._negative_signal_count,
+                        "names": dict(self._signal_names),
+                    },
                 }
             )
         )
@@ -1100,6 +1151,10 @@ class _RaindropTraceRecorder(_TraceRecorder):
             "status": self._status,
             "event_id": self._event_id or None,
             "case_count": self._case_count,
+            "signal_count": self._signal_count,
+            "positive_signal_count": self._positive_signal_count,
+            "negative_signal_count": self._negative_signal_count,
+            "signal_names": dict(self._signal_names),
             "content_policy": "metadata_only",
         }
 
@@ -1160,6 +1215,137 @@ def _trace_case_output(case: dict[str, Any]) -> dict[str, Any]:
         "source_score_count": case.get("source_score_count"),
         "selected_urls": selected_urls,
     }
+
+
+def _raindrop_case_signals(case: dict[str, Any]) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    base = _raindrop_signal_properties(case)
+    if case.get("status") == "failed":
+        signals.append(
+            _raindrop_signal(
+                "benchmark_case_failed",
+                base,
+                sentiment="NEGATIVE",
+                reason=case.get("error"),
+            )
+        )
+        return signals
+
+    benchmark_score = _score_value(case.get("benchmark_score"))
+    if benchmark_score is not None:
+        if benchmark_score >= 95:
+            signals.append(
+                _raindrop_signal(
+                    "benchmark_high_score",
+                    base,
+                    sentiment="POSITIVE",
+                    benchmark_score=benchmark_score,
+                )
+            )
+        elif benchmark_score < 90:
+            signals.append(
+                _raindrop_signal(
+                    "benchmark_low_score",
+                    base,
+                    sentiment="NEGATIVE",
+                    benchmark_score=benchmark_score,
+                )
+            )
+
+    wall_seconds = _optional_number(case.get("wall_seconds"))
+    if wall_seconds is not None and wall_seconds >= 10:
+        signals.append(
+            _raindrop_signal(
+                "benchmark_slow_case",
+                base,
+                sentiment="NEGATIVE",
+                wall_seconds=round(wall_seconds, 3),
+            )
+        )
+
+    estimated_cost = _optional_number(case.get("estimated_cost_usd"))
+    if estimated_cost is not None and estimated_cost >= 0.01:
+        signals.append(
+            _raindrop_signal(
+                "benchmark_high_cost_case",
+                base,
+                sentiment="NEGATIVE",
+                estimated_cost_usd=round(estimated_cost, 6),
+            )
+        )
+
+    raw_score = case.get("benchmark_score")
+    dimensions = raw_score.get("dimensions") if isinstance(raw_score, dict) else None
+    if isinstance(dimensions, dict):
+        for dimension_name, dimension in dimensions.items():
+            if not isinstance(dimension, dict):
+                continue
+            dimension_signals = dimension.get("signals")
+            if not dimension_signals:
+                continue
+            signals.append(
+                _raindrop_signal(
+                    "benchmark_dimension_signal",
+                    base,
+                    sentiment="NEGATIVE",
+                    dimension=dimension_name,
+                    dimension_score=dimension.get("score"),
+                    dimension_signals=dimension_signals,
+                )
+            )
+    return signals
+
+
+def _raindrop_signal(
+    name: str,
+    base: dict[str, Any],
+    *,
+    sentiment: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    properties = dict(base)
+    properties.update({key: value for key, value in extra.items() if value is not None})
+    return {
+        "name": name,
+        "sentiment": sentiment,
+        "properties": properties,
+    }
+
+
+def _raindrop_signal_properties(case: dict[str, Any]) -> dict[str, Any]:
+    metadata = case.get("pack_metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    score = case.get("pack_score")
+    score_summary = score.get("summary") if isinstance(score, dict) else {}
+    score_summary = score_summary if isinstance(score_summary, dict) else {}
+    benchmark_score = case.get("benchmark_score")
+    return {
+        "case": case.get("name"),
+        "provider": case.get("provider"),
+        "workflow": case.get("workflow"),
+        "target_id": case.get("target_id"),
+        "target_url": case.get("target_url"),
+        "target_kind": case.get("target_kind"),
+        "status": case.get("status", "ok"),
+        "pack_score": _score_value(score),
+        "benchmark_score": _score_value(benchmark_score),
+        "wall_seconds": case.get("wall_seconds"),
+        "estimated_cost_usd": case.get("estimated_cost_usd", 0.0),
+        "record_count": score_summary.get("record_count"),
+        "total_tokens": score_summary.get("total_tokens"),
+        "selected_url_count": len(metadata.get("selected_urls") or []),
+        "extract_error_count": metadata.get("extract_error_count"),
+        "content_policy": "metadata_only",
+    }
+
+
+def _score_value(value: Any) -> int | None:
+    if not isinstance(value, dict):
+        return None
+    score = value.get("score")
+    if isinstance(score, int):
+        return score
+    return None
 
 
 def _json_trace_text(payload: dict[str, Any]) -> str:
@@ -2185,6 +2371,26 @@ def _format_skipped_providers(skipped: list[Any]) -> str:
     return ", ".join(values) if values else "none"
 
 
+def _raindrop_trace_lines(trace: dict[str, Any]) -> list[str]:
+    lines = [
+        f"- Raindrop trace: `{trace.get('provider', 'none')}` / `{trace.get('status', 'disabled')}`",
+    ]
+    if trace.get("event_id"):
+        lines.append(f"- Raindrop event id: `{trace['event_id']}`")
+    if trace.get("enabled"):
+        lines.append(
+            "- Raindrop signals: "
+            f"`{int(trace.get('signal_count') or 0)}` total, "
+            f"`{int(trace.get('positive_signal_count') or 0)}` positive, "
+            f"`{int(trace.get('negative_signal_count') or 0)}` negative."
+        )
+        signal_names = trace.get("signal_names")
+        if isinstance(signal_names, dict) and signal_names:
+            rendered = ", ".join(f"{name}={count}" for name, count in sorted(signal_names.items()))
+            lines.append(f"- Raindrop signal names: `{rendered}`")
+    return lines
+
+
 def _markdown_report(report: dict[str, Any]) -> str:
     raw_targets = report.get("targets")
     targets: list[Any] = raw_targets if isinstance(raw_targets, list) else []
@@ -2244,6 +2450,8 @@ def _markdown_report(report: dict[str, Any]) -> str:
         lines.extend(["", "## Provider x Target Heatmap", "", *heatmap])
     skipped = report.get("skipped_providers")
     skipped = skipped if isinstance(skipped, list) else []
+    raw_trace = report.get("trace")
+    trace: dict[str, Any] = raw_trace if isinstance(raw_trace, dict) else {}
     lines.extend(
         [
             "",
@@ -2260,6 +2468,7 @@ def _markdown_report(report: dict[str, Any]) -> str:
                 "- Total estimated live provider cost: "
                 f"${report['summary'].get('total_estimated_live_cost_usd', 0):.6f}"
             ),
+            *_raindrop_trace_lines(trace),
             "",
         ]
     )
@@ -2360,9 +2569,8 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
         "",
         (
             "We benchmarked DocPull's local LLM-profile crawler against Parallel Search, "
-            "Parallel Context, Tavily Search + Extract, and Exa Search Contents. The v2 "
-            "shape is a provider-by-target matrix instead of a single clean docs site, "
-            "with Raindrop available as the metadata-only observability layer for traced runs."
+            "Parallel Context, Tavily Search + Extract, and Exa Search Contents across a "
+            "provider-target matrix, with Raindrop as the metadata-only observability layer."
         ),
         "",
         "## Methodology",
@@ -2375,7 +2583,7 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
         f"- Matrix providers: `{', '.join(str(value) for value in report.get('matrix_providers', []))}`",
         f"- Skipped providers: `{_format_skipped_providers(skipped)}`",
         f"- Parallel enabled: `{bool(report.get('parallel_enabled'))}`",
-        f"- Raindrop trace: `{trace.get('provider', 'none')}` / `{trace.get('status', 'disabled')}`",
+        *_raindrop_trace_lines(trace),
         (
             "- Trace content policy: metadata only. The benchmark records timings, "
             "counts, scores, costs, selected URLs, and artifact paths; it does not "
@@ -2478,8 +2686,8 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
         )
     if trace.get("enabled"):
         lines.append(
-            "- Raindrop tracing was enabled, so each case was emitted with provider, workflow, "
-            "target, prompt, settings, score, latency, cost, and selected-URL metadata."
+            "- Raindrop tracing was enabled, so each case was emitted as a tool trace and "
+            "attention-worthy cells were promoted into Raindrop signals."
         )
     else:
         lines.append(
@@ -2489,13 +2697,12 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
     lines.extend(
         [
             "",
-            "## Why This Is More Useful Than The First Run",
+            "## Why This Is Useful",
             "",
             (
-                "The first benchmark could not separate providers because every case ran against "
-                "`docs.parallel.ai`, a clean documentation site, and the pack score saturated at 100/100. "
                 "The target matrix creates provider-by-target variance in one run, and the weighted "
-                "sub-scores make that variance visible before it reaches the headline score."
+                "sub-scores make that variance visible before it reaches the headline score. "
+                "Raindrop turns those cells into traces and signals that can be compared over time."
             ),
             "",
             "Raindrop is still not the judge or retriever. It is the trace layer around the eval: "
@@ -2513,7 +2720,7 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
             "export EXA_API_KEY='<exa-key>'",
             "export RAINDROP_WRITE_KEY='<raindrop-write-key>'",
             (
-                "docpull benchmark quick --target-set v2 --provider all --trace raindrop "
+                "docpull benchmark quick --target-set provider-matrix --provider all --trace raindrop "
                 "--max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 "
                 "--max-estimated-cost 0.10"
             ),
@@ -2523,7 +2730,7 @@ def _article_markdown(report: dict[str, Any], *, title: str) -> str:
             "## Crawl Policy",
             "",
             (
-                "The v2 run keeps page caps low and runs on a spaced schedule. Public docs and "
+                "The provider matrix keeps page caps low and runs on a spaced schedule. Public docs and "
                 "pricing pages should still be treated as someone else's infrastructure: respect "
                 "robots.txt, keep concurrency conservative, and avoid tight repeated runs."
             ),
@@ -2578,7 +2785,7 @@ def _legacy_article_markdown(report: dict[str, Any], *, title: str) -> str:
         f"- Providers: `{providers}`",
         f"- Skipped providers: `{_format_skipped_providers(skipped)}`",
         f"- Parallel enabled: `{bool(report.get('parallel_enabled'))}`",
-        f"- Raindrop trace: `{trace.get('provider', 'none')}` / `{trace.get('status', 'disabled')}`",
+        *_raindrop_trace_lines(trace),
         (
             "- Trace content policy: metadata only. The benchmark records timings, "
             "counts, scores, costs, selected URLs, and artifact paths; it does not "
@@ -2634,8 +2841,8 @@ def _legacy_article_markdown(report: dict[str, Any], *, title: str) -> str:
         )
     if trace.get("enabled"):
         lines.append(
-            "- Raindrop tracing was enabled, so each benchmark case was emitted as a tool trace for "
-            "follow-up investigation and experiment tracking."
+            "- Raindrop tracing was enabled, so each benchmark case was emitted as a tool trace and "
+            "attention-worthy cells were promoted into Raindrop signals."
         )
     else:
         lines.append(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -188,6 +190,37 @@ def test_benchmark_matrix_runs_core_once_per_target(
     ]
     assert report["cases"][0]["name"] == "parallel_docs/core-llm"
     assert "Provider x Target Heatmap" in (output_dir / "benchmark.summary.md").read_text(encoding="utf-8")
+
+
+def test_provider_matrix_target_set_has_legacy_v2_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(benchmark, "_run_core_case", _fake_core_case)
+
+    report = run_quick_benchmark(
+        target_url="https://docs.parallel.ai",
+        target_set="v2",
+        output_dir=tmp_path / "bench",
+        max_pages=1,
+        max_depth=1,
+        max_concurrent=1,
+        per_host_concurrent=1,
+        cache_enabled=True,
+        cached_pass=None,
+        parallel=False,
+        parallel_objective=None,
+        parallel_queries=[],
+        include_domains=[],
+        mode="advanced",
+        max_search_results=8,
+        extract_limit=3,
+        max_estimated_cost=0.05,
+    )
+
+    assert report["target_set"] == "provider-matrix"
+    assert report["summary"]["target_count"] == 8
+    assert report["summary"]["case_count"] == 8
 
 
 def test_benchmark_records_provider_failure_and_continues(
@@ -453,6 +486,123 @@ def test_raindrop_trace_requires_write_key_before_core(
         )
 
     assert called is False
+
+
+def test_raindrop_trace_records_event_id_and_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[dict[str, Any]] = []
+    signals: list[dict[str, Any]] = []
+
+    class FakeInteraction:
+        def __init__(self, event_id: str) -> None:
+            self._event_id = event_id
+
+        def track_tool(self, **kwargs: Any) -> None:
+            events.append({"type": "tool", **kwargs})
+
+        def set_properties(self, props: dict[str, Any]) -> None:
+            events.append({"type": "properties", "props": props})
+
+        def finish(self, **kwargs: Any) -> None:
+            events.append({"type": "finish", **kwargs})
+
+    fake_raindrop = types.ModuleType("raindrop.analytics")
+
+    def fake_init(*_args: Any, **_kwargs: Any) -> None:
+        events.append({"type": "init"})
+
+    def fake_begin(**kwargs: Any) -> FakeInteraction:
+        events.append({"type": "begin", **kwargs})
+        return FakeInteraction(str(kwargs["event_id"]))
+
+    def fake_track_signal(**kwargs: Any) -> None:
+        signals.append(kwargs)
+
+    fake_raindrop.init = fake_init  # type: ignore[attr-defined]
+    fake_raindrop.begin = fake_begin  # type: ignore[attr-defined]
+    fake_raindrop.track_signal = fake_track_signal  # type: ignore[attr-defined]
+    fake_raindrop.flush = lambda: events.append({"type": "flush"})  # type: ignore[attr-defined]
+    fake_raindrop.shutdown = lambda: events.append({"type": "shutdown"})  # type: ignore[attr-defined]
+    fake_package = types.ModuleType("raindrop")
+    fake_package.analytics = fake_raindrop  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "raindrop", fake_package)
+    monkeypatch.setitem(sys.modules, "raindrop.analytics", fake_raindrop)
+    monkeypatch.setattr(benchmark, "_lookup_benchmark_secret", lambda _env_var: "test-key")
+
+    recorder = benchmark._RaindropTraceRecorder(
+        target_url="https://docs.parallel.ai",
+        targets=[
+            benchmark._BenchmarkTarget(
+                id="parallel_docs",
+                label="Parallel docs",
+                url="https://docs.parallel.ai",
+                include_domains=("docs.parallel.ai",),
+                objective="Build a pack",
+                queries=("Parallel API docs",),
+            )
+        ],
+        target_set="tool-docs",
+        output_dir=tmp_path,
+        parallel_enabled=True,
+        max_estimated_cost=0.05,
+    )
+    recorder.record_case(
+        {
+            "name": "parallel_docs/tavily-search-extract",
+            "provider": "tavily",
+            "workflow": "tavily-search-extract-pack",
+            "target_id": "parallel_docs",
+            "target_url": "https://docs.parallel.ai",
+            "target_kind": "docs",
+            "status": "failed",
+            "error": {"type": "BenchmarkError", "message": "No extractable URLs"},
+            "wall_seconds": 0.2,
+            "estimated_cost_usd": 0.0,
+        }
+    )
+    recorder.record_case(
+        {
+            "name": "parallel_docs/exa-search-contents",
+            "provider": "exa",
+            "workflow": "exa-search-contents-pack",
+            "target_id": "parallel_docs",
+            "target_url": "https://docs.parallel.ai",
+            "target_kind": "docs",
+            "status": "ok",
+            "wall_seconds": 11.2,
+            "estimated_cost_usd": 0.012,
+            "pack_score": {"score": 88, "summary": {"record_count": 2, "total_tokens": 1200}},
+            "benchmark_score": {
+                "score": 86,
+                "dimensions": {
+                    "coverage": {"score": 70, "signals": ["2/3 expected unique URLs"]},
+                },
+            },
+            "pack_metadata": {
+                "selected_urls": ["https://docs.parallel.ai/a"],
+                "extract_error_count": 1,
+            },
+        }
+    )
+    recorder.finish({"summary": {"case_count": 2}, "artifacts": {"json": "benchmark.report.json"}})
+
+    metadata = recorder.metadata()
+    assert metadata["event_id"]
+    assert metadata["case_count"] == 2
+    assert metadata["signal_count"] == 5
+    assert metadata["negative_signal_count"] == 5
+    assert {signal["name"] for signal in signals} == {
+        "benchmark_case_failed",
+        "benchmark_low_score",
+        "benchmark_slow_case",
+        "benchmark_high_cost_case",
+        "benchmark_dimension_signal",
+    }
+    assert all(signal["event_id"] == metadata["event_id"] for signal in signals)
+    assert signals[0]["properties"]["content_policy"] == "metadata_only"
+    assert any(event["type"] == "properties" and event["props"]["signal_count"] == 5 for event in events)
 
 
 def test_benchmark_article_cli_writes_publishable_markdown(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- promote Raindrop from metadata-only trace status into per-case benchmark signals
- persist Raindrop event ids and signal counts in reports/articles
- rename the matrix target set to provider-matrix while preserving v2 as a compatibility alias

## Verification
- .venv/bin/python -m pytest tests/test_benchmark.py -q
- .venv/bin/ruff check .
- git diff --check
- .venv/bin/python -m pytest -q
- live traced provider-matrix run recorded 40 cases and 108 Raindrop signals