### PR TITLE
Add OKF bundle output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ sandbox-friendly way to pipe web content into an LLM context, a RAG index, or an
 offline archive. SSRF, XXE, DNS-rebinding, and CRLF-injection protections are on
 by default — a necessity when an AI agent is choosing the URLs.
 
+docpull is intentionally not a general browser-automation scraper. See
+[`docs/scraping-boundary.md`](docs/scraping-boundary.md) for the exact product
+boundary and when to use Scrapy, Crawlee, hosted extraction APIs, or trafilatura
+directly.
+
 ## Install
 
 ```bash
@@ -67,6 +72,9 @@ docpull https://docs.example.com/guide --single
 # LLM-ready NDJSON with 4k-token chunks streamed to stdout
 docpull https://docs.example.com --profile llm --stream | jq .
 
+# Open Knowledge Format bundle for agent/wiki interoperability
+docpull https://docs.example.com --format okf
+
 # Mirror scraped content for offline use
 docpull https://docs.example.com --profile mirror --cache
 ```
@@ -81,8 +89,13 @@ content directly from framework data feeds:
 | Next.js   | Parses `__NEXT_DATA__` JSON |
 | Mintlify  | `__NEXT_DATA__` with Mintlify tagging |
 | OpenAPI   | Renders `openapi.json` / `swagger.json` into Markdown |
-| Docusaurus| Detected and tagged; generic extractor produces Markdown |
-| Sphinx    | Detected from generator metadata / Read the Docs hosts and tagged; generic extractor produces Markdown |
+| Docusaurus| Extracts static article regions and tags framework metadata |
+| Sphinx    | Extracts static body/document regions and tags framework metadata |
+| MkDocs / Material | Extracts static content regions and tags framework metadata |
+| VitePress / VuePress | Extracts static doc regions and tags framework metadata |
+| Astro Starlight | Extracts static markdown content regions and tags framework metadata |
+| GitBook / ReadMe.io | Extracts static article/content regions and tags framework metadata |
+| Redoc / Scalar | Extracts static API reference regions; OpenAPI JSON is still preferred when available |
 
 JS-only SPAs with no server-rendered content are detected and skipped with a
 clear reason (or, with `--strict-js-required`, reported as an error so agents
@@ -101,6 +114,30 @@ can route elsewhere).
   for sites where the default heuristics struggle.
 
 ## Python API
+
+Scraper-facing API:
+
+```python
+import asyncio
+from docpull import scrape_one, Scraper
+
+async def main():
+    page = await scrape_one("https://docs.python.org/3/library/asyncio.html")
+    print(page.title, page.source_type)
+    print(page.text[:500])
+
+    scraper = Scraper()
+    run = await scraper.scrape_site(
+        "https://docs.example.com",
+        output_format="ndjson",
+        max_pages=100,
+    )
+    print(run.stats.pages_fetched, run.manifest_path)
+
+asyncio.run(main())
+```
+
+Core fetcher API:
 
 ```python
 from docpull import fetch_one
@@ -146,6 +183,7 @@ async def tool_call(url: str) -> str:
 ```bash
 docpull https://site.com --profile rag      # Default. Dedup, rich metadata.
 docpull https://site.com --profile llm      # NDJSON + chunks + metadata; JS-only pages skip unless --strict-js-required is passed.
+docpull https://site.com --profile okf      # OKF bundle with generated index.md files.
 docpull https://site.com --profile mirror   # Full archive, polite, cached, hierarchical paths.
 docpull https://site.com --profile quick    # Sampling: 50 pages, depth 2.
 ```
@@ -427,10 +465,42 @@ NDJSON (one record per page or chunk):
 {"document_id": "doc_...", "chunk_id": "chunk_...", "url": "...", "title": "...", "content": "...", "hash": "...", "token_count": 842, "chunk_index": 0}
 ```
 
+Open Knowledge Format:
+
+```bash
+docpull https://docs.example.com --format okf
+```
+
+OKF output is an opt-in Markdown bundle. Scraped pages are written as concept
+documents with OKF frontmatter (`type`, `title`, `description`, `resource`,
+`tags`, `timestamp` when source metadata exists) and docpull keeps `source` as a
+compatibility extension. Generated `index.md` files are reserved for directory
+listings, so URL landing pages use safe concept filenames such as `_root.md` or
+`_page.md` instead of occupying `index.md`. The root `index.md` declares
+`okf_version: "0.1"`; nested indexes stay plain listing files.
+
+Because OKF treats every non-reserved `.md` file in the tree as a concept, write
+OKF output to a clean or dedicated directory rather than mixing it with unrelated
+Markdown files.
+
 Every output format also writes `corpus.manifest.json` next to the generated
 documents. The manifest records the run identity, output format, stable
-`document_id` / `chunk_id` values, content hashes, relative output paths, and
-chunk counts so regenerated corpora can be diffed and cited by agents.
+`document_id` / `chunk_id` values, content hashes, file-backed relative output
+paths (or the stdout marker for streamed NDJSON), and chunk counts so
+regenerated corpora can be diffed and cited by agents. See
+[`docs/corpus-manifest.md`](docs/corpus-manifest.md) for the schema and
+stability contract.
+
+SQLite output includes an FTS5 index for local retrieval:
+
+```python
+from pathlib import Path
+from docpull import search_sqlite_documents
+
+hits = search_sqlite_documents(Path("docs/documents.db"), "rate limit")
+for hit in hits:
+    print(hit.url, hit.snippet)
+```
 
 ## Security
 
@@ -451,9 +521,9 @@ Run `docpull --help` for the full list. Highlights:
 
 ```
 Core:
-  --profile {rag,mirror,quick,llm}
+  --profile {rag,mirror,quick,llm,okf}
   --single                Fetch one URL (no crawl)
-  --format {markdown,json,ndjson,sqlite}
+  --format {markdown,json,ndjson,sqlite,okf}
   --stream                Stream NDJSON to stdout
 
 LLM / chunking:

--- a/audit/00_EXECUTIVE_SUMMARY.md
+++ b/audit/00_EXECUTIVE_SUMMARY.md
@@ -2,56 +2,77 @@
 
 ## What DocPull Is
 
-DocPull is a Python CLI/library that fetches static documentation pages over async HTTP, validates URLs against SSRF policy, respects robots.txt, converts content to Markdown/JSON/NDJSON/SQLite-oriented records, and exposes a package-shipped Python stdio MCP server for agent use. The repo also contains a separate Bun/TypeScript `mcp/` server with PostgreSQL/pgvector semantic search and a Claude Code plugin bundle.
+DocPull is a Python CLI/library for browser-free web scraping of static and
+server-rendered pages into local agent-ready context. Its sharpest workflow is
+documentation ingestion: async HTTP fetch, sitemap/static-link discovery,
+SSRF-hardened URL validation, robots.txt compliance, Markdown conversion,
+chunking, manifests, and output sinks for Markdown, JSON, NDJSON, SQLite, and
+Open Knowledge Format.
 
-Audit target/version evidence:
-- `pyproject.toml:6-7` declares package `docpull` version `4.0.0`.
-- `python -m pip show docpull` in `.venv` reports editable package `Version: 4.0.0`.
-- Git `HEAD` is `a3a288e chore(release): 4.0.0 (#48)`.
-- Current worktree is dirty and currently broken at import time; this is not a clean 4.0.0 runtime.
+The repo also ships a Python stdio MCP server for agent use, optional Parallel
+provider pack workflows, a Claude Code plugin bundle, a product website, and an
+internal Bun/TypeScript MCP lab tree.
+
+Current audit target evidence:
+
+- `pyproject.toml` declares package `docpull` version `4.2.0`.
+- `.venv/bin/python -m pip show docpull` reports version `4.2.0` with editable
+  project location `/Users/mb1/Code/raintree/docpull`.
+- Git `HEAD` is `a6cce31`.
+- The current worktree is dirty because unreleased OKF, scraper API, SQLite
+  FTS, framework extractor, docs, and audit updates are in progress.
 
 ## What Works
 
-Verified by static evidence and tests present in the repo:
-- Strong URL validation design: HTTPS-only defaults, localhost/internal suffix blocks, private/link-local/reserved/multicast/CGNAT IP blocks, IPv4-mapped IPv6 handling, and single-resolution `resolve_allowed_addresses()` in `src/docpull/security/url_validator.py:48-197`.
-- Connect-time DNS pinning in aiohttp when no proxy is configured via `_ValidatedResolver` in `src/docpull/http/client.py:32-76` and `AsyncHttpClient.__aenter__` in `src/docpull/http/client.py:269-285`.
-- Redirect revalidation and auth stripping across origins in `src/docpull/http/client.py:203-267`.
-- robots.txt fail-closed behavior, redirect handling, pinned HTTPS connection, and 512 KB cap in `src/docpull/security/robots.py:97-203`.
-- Sitemap XML parsing uses `defusedxml` with size/depth limits in `src/docpull/discovery/sitemap.py:9-43` and `149-186`.
-- Python MCP tool surface and schemas are defined for 8 tools with annotations and structured output in `src/docpull/mcp/server.py:225-485`.
-- MCP path traversal and ReDoS mitigations exist in `src/docpull/mcp/tools.py:462-628` and `631-706`.
+Current local verification:
 
-## What Is Risky
+- `.venv/bin/pytest -q` passed: 522 tests.
+- `.venv/bin/mypy src/docpull` passed: 73 source files.
+- `.venv/bin/ruff check .` passed.
+- `.venv/bin/python -m docpull --version` reports `docpull 4.2.0`.
+- `.venv/bin/python -m docpull --help`, `--doctor`, and `mcp --help` pass.
 
-Top confirmed risks/gaps:
-1. **Critical local worktree breakage**: `docpull --version`, `docpull --help`, `docpull --doctor`, tests, and coverage all fail to import because `FetchEvent.progress()` annotates `-> FetchEvent` without postponed annotations in `src/docpull/models/events.py:131-140`.
-2. **Docs/runtime mismatch**: README says LLM profile is agent/LLM-ready and the profile comment says fail-loud on JS-only pages, but `ProfileName.LLM` sets `strict_js_required=False` in `src/docpull/models/profiles.py:47-64`.
-3. **CLI/config mismatch**: CLI accepts `--naming-strategy flat|short` in `src/docpull/cli.py:136-143`, while `OutputConfig.naming_strategy` only accepts `full|hierarchical` in `src/docpull/models/config.py:145-150`.
-4. **Plugin cache path mismatch**: plugin README claims `$XDG_DATA_HOME/docpull/docs` / `~/.local/share/docpull/docs`, but Python MCP defaults to `$XDG_DATA_HOME/docpull-mcp/docs` / `~/.local/share/docpull-mcp/docs` in `src/docpull/mcp/sources.py:114-120`.
-5. **README mirror claim unverified**: README claims root `mcp/` is mirrored to `raintree-technology/docpull-mcp` in `README.md:211-219`; browser/search evidence did not verify a public mirror.
-6. **Current audit could not run functional crawl tests** because import failure blocks runtime validation.
-7. **pip install and pip-audit were blocked by DNS/network restrictions**, so dependency vulnerability verification is incomplete.
-8. **Proxy mode weakens DNS-pinning guarantees by design**; `--require-pinned-dns` exists, but default proxy behavior still relies on users/agents understanding the warning.
-9. **Root TypeScript MCP is duplicated product surface** with different tools, versioning, cache metadata, and deployment assumptions than Python MCP.
-10. **Performance claims are only partially verified**: benchmark test code exists, but current worktree cannot collect tests.
+Implemented and covered by tests:
 
-## Top 10 Improvements
+- Strong URL validation: HTTPS defaults, localhost/internal suffix blocks,
+  private/link-local/reserved/multicast/CGNAT IP blocks, IPv4-mapped IPv6
+  handling, and connect-time DNS pinning when no proxy delegates DNS.
+- Redirect revalidation and auth stripping across origins.
+- robots.txt handling, sitemap parsing through `defusedxml`, static link
+  crawling, include/exclude path filters, rate limits, and streaming discovery.
+- Framework-aware extraction for Next.js, Mintlify, OpenAPI, raw Markdown/text,
+  Docusaurus, and Sphinx fixtures.
+- Structured output records with stable document/chunk IDs, content hashes,
+  corpus manifests, source indexes, and output path source maps.
+- OKF bundle output with reserved `index.md` handling and generated indexes.
+- SQLite output with an FTS5 search index and Python search helper.
+- First-class scraper-facing API names over the existing Fetcher engine:
+  `Scraper`, `scrape_one`, `scrape_site`, and `ScrapeResult`.
 
-1. Fix the current import blocker and make `ruff`, `mypy`, `pytest`, and CLI smoke tests green before any expansion.
-2. Align LLM profile docs/comment/behavior: either set `strict_js_required=True` or remove fail-loud wording.
-3. Remove deprecated `flat`/`short` from CLI choices or map them before Pydantic validation with explicit deprecation messaging.
-4. Fix plugin README cache path and version prerequisite (`2.5.0 or newer` should be `4.0.0 or newer` if current plugin targets v4).
-5. Decide root `mcp/` strategy: split to public repo, mark experimental/private, or fold roadmap into Python MCP.
-6. Add a clean-release CI gate that imports `docpull`, runs `docpull --version`, `--help`, `--doctor`, and `docpull mcp --help`.
-7. Add end-to-end localhost fixtures for every advertised output format and profile.
-8. Add security regression tests for proxy warning/`--require-pinned-dns`, decompression bombs, symlink cache/output attacks, and source registry poisoning.
-9. Add docs architecture/security model pages so users understand browser-free constraints and trust boundaries.
-10. Prioritize agent-native output work: stable chunk IDs, manifest schema, citation/source maps, and optional SQLite FTS.
+## Current Risks
 
-## 30/60/90 Day Recommendation
+1. The new work is unreleased and still needs review before publishing.
+2. Proxy mode still weakens DNS-pinning guarantees by design unless
+   `--require-pinned-dns` is used.
+3. Optional JavaScript rendering remains intentionally out of scope for the
+   default product; it should only land behind a separate explicit adapter.
+4. Authenticated/internal docs mode is still strategic work and needs source
+   policy, redaction, audit logging, and secret-scoping design before expansion.
+5. Live-regression captures remain valuable for docs frameworks whose static
+   fixture coverage is now present but whose real pages can drift.
+6. Root TypeScript MCP remains a separate/internal surface and should not become
+   the primary documented MCP path unless that strategy is deliberately changed.
 
-30 days: stabilize correctness/security/docs. Fix current runtime breakage, resolve claim gaps, publish a patch, and add CLI/MCP smoke tests that would have caught the import failure.
+## Strategic Direction
 
-60 days: productize agent workflows. Harden plugin docs, add per-project caches, `/docs-skill`, stable chunk IDs, manifest schema, and a verified cookbook against small fixture docs sites.
+Do not turn DocPull into a general browser automation scraper. Scrapy, Crawlee,
+hosted extraction services, and trafilatura already cover adjacent broader
+categories. DocPull should deepen the local, auditable, browser-free
+web-to-agent-context lane:
 
-90 days: strategic expansion. Add optional JS rendering adapter, authenticated/internal docs model, semantic search path, SQLite FTS, and framework extractors for MkDocs, VitePress, Starlight, GitBook, ReadMe.io, and Redoc/Scalar variants.
+1. Finish release hygiene and keep CLI/API/MCP smoke tests green.
+2. Keep the scraper API as a thin, stable facade over Fetcher.
+3. Expand framework fixtures before adding browser rendering.
+4. Improve local retrieval, manifests, source maps, and pack diff/scoring.
+5. Add authenticated/internal docs mode only after the security model is
+   explicit and tested.

--- a/audit/01_CONTEXT.md
+++ b/audit/01_CONTEXT.md
@@ -20,9 +20,10 @@
 - Security: `src/docpull/security/url_validator.py`, `robots.py`.
 - Discovery: `src/docpull/discovery/sitemap.py`, `crawler.py`, `filters.py`, `link_extractors/`.
 - Conversion: `src/docpull/conversion/extractor.py`, `markdown.py`, `special_cases.py`, `trafilatura_extractor.py`, `chunking.py`.
-- Pipeline: `src/docpull/pipeline/base.py` plus `steps/validate.py`, `fetch.py`, `convert.py`, `metadata.py`, `dedup.py`, `chunk.py`, `save.py`, `save_json.py`, `save_ndjson.py`, `save_sqlite.py`.
+- Pipeline: `src/docpull/pipeline/base.py` plus `steps/validate.py`, `fetch.py`, `convert.py`, `metadata.py`, `dedup.py`, `chunk.py`, `save.py`, `save_json.py`, `save_ndjson.py`, `save_sqlite.py`, `save_okf.py`.
 - Cache/resume: `src/docpull/cache/manager.py`, `streaming_dedup.py`, dirty-worktree `frontier.py`.
 - Python MCP: `src/docpull/mcp/server.py`, `tools.py`, `sources.py`.
+- Scraper facade: `src/docpull/scraper.py`.
 
 ## Runtime Data Flow
 
@@ -33,7 +34,7 @@
 5. Discovery uses sitemaps plus link crawling: `SitemapDiscoverer` and `LinkCrawler`.
 6. Each URL enters `FetchPipeline.execute_result()` in `src/docpull/pipeline/base.py:181-222`.
 7. Pipeline validates URL/robots/cache, fetches bytes, converts/special-cases, extracts metadata, deduplicates/chunks, and saves.
-8. Output writers persist Markdown, JSON, NDJSON, or SQLite records.
+8. Output writers persist Markdown, JSON, NDJSON, SQLite, or OKF records.
 9. `Fetcher.run()` emits `FetchEvent` records for CLI/MCP/progress consumers.
 
 ## Trust Boundaries
@@ -56,13 +57,14 @@
 - Add MCP tools in `src/docpull/mcp/server.py` and implementations in `tools.py`.
 - Add Claude Code UX in `plugin/commands` and `plugin/skills`.
 - Add semantic/FTS storage in SQLite or root `mcp/` DB layer.
+- Add scraper-facing convenience APIs in `src/docpull/scraper.py` without duplicating the Fetcher engine.
 
 ## Duplicated/Dead Systems
 
 - Python MCP and root TypeScript MCP are separate products with different capabilities and operational models.
 - Root `mcp/package.json:2-3` says `docpull-mcp` version `0.3.0`, while `mcp/src/server.ts:396` initializes server version `0.2.0`.
-- README points to a root `mcp/` mirror that appears unverified/publicly unavailable.
-- Current dirty worktree introduces `src/docpull/cache/frontier.py`, `models/document.py`, `models/run.py`, SQLite/frontier tests, and pipeline changes, but the import failure prevents validating them.
+- Root `mcp/` should stay clearly documented as a separate/internal surface unless it is deliberately split or promoted.
+- Current dirty worktree adds unreleased OKF output, scraper API, SQLite FTS, framework extractors, and docs/audit updates; local test/type/lint gates should be rerun before release.
 
 ## Dependency Graph
 
@@ -85,6 +87,6 @@ CLI/Python API/MCP
       -> MetadataStep
       -> DedupStep
       -> ChunkStep
-      -> SaveStep / JsonSaveStep / NdjsonSaveStep / SqliteSaveStep
+      -> SaveStep / JsonSaveStep / NdjsonSaveStep / SqliteSaveStep / OkfSaveStep
     -> CacheManager / StreamingDeduplicator
 ```

--- a/audit/02_FUNCTIONALITY_MATRIX.md
+++ b/audit/02_FUNCTIONALITY_MATRIX.md
@@ -1,34 +1,43 @@
 # Functionality Matrix
 
-| Feature | Documented? | Implemented? | Tested? | Verified by audit? | Evidence | Gaps | Priority |
-|---|---:|---:|---:|---:|---|---|---|
-| Package version 4.0.0 | Yes | Yes | Partial | Yes | `pyproject.toml:6-7`, `pip show docpull` | Runtime CLI blocked in dirty worktree | P0 |
-| CLI `--version` | Yes | Yes | Yes | Broken in worktree | `cli.py:76-80`; command fails importing `FetchEvent` | Fix import blocker | P0 |
-| CLI `--help` | Yes | Yes | Partial | Broken in worktree | `cli.py:48-369`; command fails importing `FetchEvent` | Add no-import-regression smoke | P0 |
-| CLI `--doctor` | Yes | Yes | Unknown | Broken in worktree | `cli.py:10-20`, `doctor.py`; command fails before doctor path through script import | Make doctor import-light | P0 |
-| `--single` | Yes | Yes | Partial | Static only | `README.md:44-45`, `cli.py:97-101`, `cli.py:547-565` | Runtime blocked | P0 |
-| Profiles `rag/mirror/quick/llm` | Yes | Yes | Yes | Partial | `README.md:124-131`, `profiles.py:9-69` | LLM fail-loud claim mismatch | P0 |
-| Markdown output | Yes | Yes | Yes | Static only | `OutputConfig.format` in `config.py:140-144`, `SaveStep` | Runtime blocked | P0 |
-| JSON output | Yes | Yes | Yes | Static only | `cli.py:129-134`, `JsonSaveStep` present | Schema docs thin | P1 |
-| NDJSON/stream output | Yes | Yes | Yes | Static only | `README.md:237-241`, `save_ndjson.py:25-69` | Runtime blocked | P0 |
-| SQLite output | Yes | Yes | New tests | Static only | `config.py:141`, `save_sqlite.py`, `test_save_sqlite.py` | Worktree changes blocked; docs minimal | P0 |
-| Cache/incremental | Yes | Yes | Yes | Static only | `cli.py:312-342`, `FetchStep` conditional headers | Runtime blocked | P0 |
-| Resume/frontier | Site/docs claim | Worktree partial | New tests | Broken/unverified | `web/components/Features.tsx:18-20`, dirty `frontier.py` | Import failure blocks; public HEAD may not include frontier | P0 |
-| SSRF controls | Yes | Yes | Yes | Static + tests present | `url_validator.py:48-197`, `test_security_hardening.py` | Need decompression/proxy edge tests | P1 |
-| DNS pinning | Yes | Yes | Yes | Static | `http/client.py:32-76`, `robots.py:47-76` | Proxy mode weaker by design | P1 |
-| robots.txt mandatory | Yes | Yes | Yes | Static | `validate.py:96-107`, `robots.py:193-203` | Crawl-delay not clearly enforced from robots | P1 |
-| Sitemap discovery | Yes | Yes | Yes | Static | `sitemap.py:23-43`, tests in `test_discovery.py` | Size checked after response already in memory | P1 |
-| Link crawling | Yes | Yes | Yes | Static | `crawler.py:25-42`, `143-229` | Need canonical URL behavior docs/tests | P2 |
-| Next.js extraction | Yes | Yes | Yes | Static | `README.md:59-65`, `special_cases.py:85-171` | App Router coverage partial | P2 |
-| Mintlify extraction | Yes | Yes | Yes | Static | `special_cases.py:193-214` | Delegates to Next only | P2 |
-| Docusaurus/Sphinx | Yes | Partial | Partial | Partial | Docusaurus detector returns `None` intentionally at `special_cases.py:174-190`; README says tagged/generic | Sphinx implementation not evident in inspected snippet; claim needs direct test/code trace | P1 |
-| OpenAPI extraction | Yes | Yes | Yes | Static | `special_cases.py:306-360` | Needs Redoc/Scalar variants | P2 |
-| JS-only detection | Yes | Yes | Yes | Static | tests `test_spa_detected_and_skipped`, `test_strict_js_required_raises_error` | LLM profile not strict despite comment | P0 |
-| Rich metadata | Yes | Yes | Yes | Static | `metadata_extractor.py:36-92` | Potential extruct parser limits not documented | P1 |
-| YAML frontmatter hardening | Yes | Yes | Yes | Static | `markdown.py:218-277`, changelog `docs/CHANGELOG.md:28-30` | Add fuzz/regression corpus | P1 |
-| Python API `fetch_one` | Yes | Yes | Partial | Broken in worktree | `README.md:83-122`, `__init__.py`, `fetcher.py` | Import failure blocks | P0 |
-| Python MCP 8 tools | Yes | Yes | Yes | Static | `README.md:184-198`, `server.py:225-485`, `test_mcp_server.py` | Runtime blocked | P0 |
-| MCP structuredContent | Yes | Yes | Yes | Static | `server.py:596-599`, schemas in `server.py:54-183` | Errors intentionally no structuredContent | P1 |
-| Claude plugin slash commands | Yes | Yes | Partial | Static | `plugin/README.md:7-18`, `plugin/commands/*` | Cache path docs wrong | P0 |
-| Root TypeScript MCP mirror | Yes | Yes in-tree | Some TS tests | Unverified public mirror | `README.md:211-219`, `mcp/package.json:1-19` | Public repo unavailable/unverified | P1 |
-| Performance 10k benchmark | Yes | Yes | Yes | Not run | `.github/workflows/benchmark.yml`, `tests/benchmarks/test_10k_pages.py` | Import failure prevents local run | P0 |
+| Feature | Documented? | Implemented? | Tested? | Current status | Evidence / next step |
+| --- | ---: | ---: | ---: | --- | --- |
+| Package version 4.2.0 | Yes | Yes | Smoke | Working | `pyproject.toml`; `.venv/bin/python -m docpull --version` |
+| CLI `--help` / `--version` | Yes | Yes | Smoke | Working | Final release gate should rerun direct CLI smoke |
+| Profiles `rag/mirror/quick/llm/okf` | Yes | Yes | Yes | Working | Profile tests and CLI parser tests |
+| `--single` in-memory fast path | Yes | Yes | Yes | Working | Fetcher and scraper API e2e tests |
+| Scraper-facing API | Yes | Yes | Yes | Working | `docpull.scraper`, README examples, local e2e test |
+| Markdown output | Yes | Yes | Yes | Working | Output e2e tests |
+| JSON output | Yes | Yes | Yes | Working | Output e2e tests plus manifest assertion |
+| NDJSON / stream output | Yes | Yes | Yes | Working | Output e2e tests plus `sources.md` support |
+| SQLite output | Yes | Yes | Yes | Working | SQLite schema tests |
+| SQLite FTS retrieval | Yes | Yes | Yes | Working | `documents_fts`, `search_sqlite_documents()` tests |
+| OKF output | Yes | Yes | Yes | Working | OKF e2e conformance test |
+| Corpus manifest | Yes | Yes | Yes | Working | Manifest assertions and `docs/corpus-manifest.md` |
+| Stable document/chunk IDs | Yes | Yes | Yes | Working | `tests/test_document_record.py` |
+| Cache/incremental | Yes | Yes | Yes | Working | Existing cache tests; still worth full release gate |
+| Resume/frontier | Partial | Yes | Yes | Working but needs docs | Existing frontier/cache tests; update product docs if promoted |
+| SSRF controls | Yes | Yes | Yes | Working | Security hardening tests |
+| DNS pinning | Yes | Yes | Yes | Working without proxy | Proxy mode remains documented caveat |
+| robots.txt mandatory | Yes | Yes | Yes | Working | Robots tests |
+| Sitemap discovery | Yes | Yes | Yes | Working | Discovery tests |
+| Link crawling | Yes | Yes | Yes | Working | Discovery tests |
+| Next.js extraction | Yes | Yes | Yes | Working | Special-case tests |
+| Mintlify extraction | Yes | Yes | Yes | Working | Special-case tests |
+| Docusaurus extraction/tagging | Yes | Yes | Yes | Working | Static article fixture |
+| Sphinx extraction/tagging | Yes | Yes | Yes | Working | Static body fixture |
+| MkDocs/Material extraction/tagging | Yes | Yes | Yes | Working | Static content fixture |
+| VitePress extraction/tagging | Yes | Yes | Yes | Working | Static content fixture |
+| Starlight extraction/tagging | Yes | Yes | Yes | Working | Static content fixture |
+| GitBook extraction/tagging | Yes | Yes | Yes | Working | Static content fixture |
+| ReadMe.io extraction/tagging | Yes | Yes | Yes | Working | Static content fixture |
+| Redoc/Scalar static extraction/tagging | Yes | Yes | Yes | Working | Static API reference fixture |
+| OpenAPI extraction | Yes | Yes | Yes | Working | Special-case tests |
+| Raw Markdown/text extraction | Yes | Yes | Yes | Working | Special-case tests |
+| JS-only detection | Yes | Yes | Yes | Working | Strict/skip tests |
+| Rich metadata | Yes | Yes | Yes | Working | Metadata and output tests |
+| Python MCP | Yes | Yes | Yes | Working | MCP tests; final release gate should include `docpull mcp --help` |
+| Claude plugin docs | Yes | Yes | Yes | Working | Cache path/version regression in `tests/test_ci_policy.py` |
+| Root TypeScript MCP | Partial | In-tree | Some TS tests | Strategy risk | Keep marked internal unless deliberately promoted |
+| Optional JS rendering | Boundary only | No | No | Out of default scope | Add only behind explicit extra and policy |
+| Authenticated/internal docs product mode | Partial primitives | Partial | Partial | Strategic, not promoted | Needs allowlist/redaction/audit design |

--- a/audit/03_SECURITY_REVIEW.md
+++ b/audit/03_SECURITY_REVIEW.md
@@ -2,112 +2,97 @@
 
 ## Threat Model
 
-DocPull accepts URLs from users and AI agents, fetches remote content, parses HTML/XML/JSON/YAML-like metadata, follows links and redirects, writes local files/cache manifests, and exposes local cached docs through MCP. It may run in developer environments containing cloud credentials, source code, SSH keys, API tokens, and private network access.
+DocPull accepts URLs from users and AI agents, fetches remote content, parses
+HTML/XML/JSON/metadata, follows links and redirects, writes local files/cache
+manifests, and exposes local cached docs through MCP. It may run in developer
+environments containing cloud credentials, source code, SSH keys, API tokens,
+and private network access.
 
 Primary attacker capabilities:
-- Provide malicious URL, hostname, DNS behavior, redirects, HTML, robots.txt, sitemap XML, OpenAPI JSON, or metadata.
+
+- Provide malicious URL, hostname, DNS behavior, redirects, HTML, robots.txt,
+  sitemap XML, OpenAPI JSON, or metadata.
 - Influence cached validator headers by controlling prior server responses.
 - Hand-edit MCP `sources.yaml` or convince an agent to add malicious sources.
-- Plant symlinks or strange paths in output/cache dirs if local filesystem boundary is weak.
+- Plant symlinks or strange paths in output/cache dirs if local filesystem
+  boundaries are weak.
 - Trigger expensive regexes through MCP search.
 
 ## Confirmed Mitigations
 
-- HTTPS-only default: `UrlValidator.DEFAULT_ALLOWED_SCHEMES = {"https"}` in `src/docpull/security/url_validator.py:48-50`.
-- Local/private/internal host blocking: `url_validator.py:50-57`, `211-237`.
-- DNS root-dot stripping: `url_validator.py:113-121`.
-- DNS rebinding TOCTOU mitigation: single resolution returned from `resolve_allowed_addresses()` in `url_validator.py:159-197`; aiohttp resolver dials those addresses in `http/client.py:32-76`.
-- Redirect target validation: `http/client.py:203-267`.
-- Sensitive auth header stripping cross-origin: `http/client.py:209-235`.
-- robots.txt pinned HTTPS and fail-closed behavior: `security/robots.py:47-76`, `151-203`.
-- robots.txt 512 KB body cap: `security/robots.py:97-99`.
-- XXE-resistant sitemap parsing: `discovery/sitemap.py:9-10`, `149-166`.
-- YAML frontmatter injection mitigation: `conversion/markdown.py:218-277`.
-- Conditional request header sanitization: `pipeline/steps/fetch.py` contains `_sanitize_validator_header` per grep evidence.
-- MCP library/path traversal controls: `mcp/sources.py:65-72`, `mcp/tools.py:647-665`.
-- MCP ReDoS controls: `mcp/tools.py:45-49`, `485-500`, `537-541`.
+- HTTPS-only default URL policy.
+- Local/private/internal host blocking, including CGNAT and IPv4-mapped IPv6.
+- DNS root-dot stripping.
+- DNS-rebinding TOCTOU mitigation via single screened resolution and
+  connect-time address pinning when not using a proxy.
+- Redirect target validation.
+- Sensitive auth header stripping across origins.
+- robots.txt handling and body cap.
+- XXE-resistant sitemap parsing via `defusedxml`.
+- YAML frontmatter injection mitigation.
+- Conditional request header sanitization.
+- MCP library/path traversal controls.
+- MCP regex length and timeout controls.
+- Output path validation for save steps.
 
 ## Findings
 
-### SEC-001: Current worktree import failure disables security/runtime verification
-
-- Severity: High
-- Confidence: High
-- Surface: CLI, Python API, Python MCP, tests
-- Evidence: `src/docpull/models/events.py:131-140` annotates `FetchEvent.progress(...)-> FetchEvent` without `from __future__ import annotations`; `docpull --version`, `--help`, `--doctor`, `pytest`, and coverage fail with `NameError: name 'FetchEvent' is not defined`.
-- Reproduction: `./.venv/bin/docpull --version`.
-- Expected: version output.
-- Actual: import traceback before argument parsing.
-- Recommended fix: add postponed annotations or quote return type; add CLI import smoke tests.
-- Tests to add: `test_import_docpull_package`, `test_cli_version_no_network`, `test_mcp_subcommand_help_no_import_failure`.
-
-### SEC-002: Proxy mode weakens DNS pinning unless user opts into `--require-pinned-dns`
+### SEC-001: Proxy mode delegates DNS pinning unless user opts into `--require-pinned-dns`
 
 - Severity: Medium
 - Confidence: High
 - Surface: CLI/network
-- Evidence: `AsyncHttpClient.__aenter__` logs warning and disables `_ValidatedResolver` when `_proxy is not None` in `src/docpull/http/client.py:269-279`; `require_pinned_dns` rejects proxy mode in `src/docpull/http/client.py:162-168`.
-- Reproduction: configure `--proxy` without `--require-pinned-dns`.
-- Expected: security model remains clear and enforceable for agent use.
-- Actual: DNS resolution is delegated to proxy after preflight URL validation.
 - Current mitigation: warning plus `--require-pinned-dns`.
-- Gap: agents/users may miss warning; docs mention it but default remains weaker.
-- Recommended fix: for MCP/agent paths, default to requiring pinned DNS or require explicit `allow_proxy_dns=true`.
-- Tests: CLI config test for `--proxy --require-pinned-dns`; MCP/Fetcher test ensuring proxy warning and rejection behavior.
+- Risk: agents/users may miss the warning and assume the same DNS-pinning
+  guarantee applies through the proxy.
+- Recommended fix: for MCP/agent paths, require explicit opt-in to delegated
+  proxy DNS or default to pinned DNS.
+- Tests: CLI config test for `--proxy --require-pinned-dns`; Fetcher/MCP test
+  ensuring proxy rejection behavior.
 
-### SEC-003: Sitemap size limit is applied after full response materialization
+### SEC-002: Sitemap size limit is applied after generic HTTP read
 
 - Severity: Medium
 - Confidence: Medium
 - Surface: sitemap fetch
-- Evidence: `_fetch_sitemap()` calls `response = await self._client.get(url)` then checks `len(response.content) > MAX_SITEMAP_SIZE` in `src/docpull/discovery/sitemap.py:132-143`.
-- Reproduction: malicious sitemap endpoint streams >50 MB but HTTP client max is higher/default 50 MB.
-- Expected: streaming cap at sitemap limit.
-- Actual: response may be read into memory up to generic client cap before sitemap-specific rejection.
-- Current mitigation: generic HTTP max content size and sitemap post-check.
-- Gap: sitemap-specific cap is not enforced during read.
-- Recommended fix: add per-request max body override to HTTP client and use 512 KB or 50 MB intentionally; document exact cap.
-- Tests: local server streaming oversized sitemap and assert early abort below memory budget.
+- Current mitigation: generic HTTP response-size caps plus sitemap post-check.
+- Risk: a sitemap-specific cap may not abort as early as intended.
+- Recommended fix: add per-request body limit override to the HTTP client and
+  use it for sitemaps/robots with tests against streaming oversized responses.
 
-### SEC-004: Plugin docs direct users to wrong cache path, which can cause stale/private data confusion
-
-- Severity: Low
-- Confidence: High
-- Surface: Claude plugin user docs
-- Evidence: `plugin/README.md:63-65` says `$XDG_DATA_HOME/docpull/docs`; `default_docs_dir()` returns `$XDG_DATA_HOME/docpull-mcp/docs` or `~/.local/share/docpull-mcp/docs` in `src/docpull/mcp/sources.py:114-120`.
-- Reproduction: run `list_indexed()` after fetch and inspect default directory.
-- Expected: docs path matches implementation.
-- Actual: plugin docs point to a different directory.
-- Recommended fix: update plugin README and troubleshooting.
-- Tests: documentation lint or unit test asserting README contains `docpull-mcp/docs`.
-
-### SEC-005: MCP user source registry has no cross-process lock
+### SEC-003: MCP user source registry has no cross-process lock
 
 - Severity: Low
 - Confidence: High
 - Surface: `add_source` / `remove_source`
-- Evidence: `_write_user_sources()` notes "Last writer wins - no cross-process lock" in `src/docpull/mcp/tools.py:721-728`.
-- Reproduction: concurrent MCP/server/manual writes to `sources.yaml`.
-- Expected: no lost updates.
-- Actual: possible lost update.
-- Current mitigation: atomic replace prevents partial file.
-- Recommended fix: file lock around read-modify-write or document single-writer assumption.
-- Tests: concurrent add/remove simulation with lock.
+- Current mitigation: atomic replace prevents partial writes.
+- Risk: concurrent writers can lose updates.
+- Recommended fix: file lock around read-modify-write or document single-writer
+  assumption.
 
-### SEC-006: `read_doc` large-file guard prevents full reads but allows slice request only after size rejection
+### SEC-004: Authenticated/internal docs mode is not a complete product model
 
-- Severity: Info
-- Confidence: Medium
-- Surface: MCP `read_doc`
-- Evidence: `read_doc` rejects any file >1 MB before reading even if line slice is requested in `src/docpull/mcp/tools.py:666-671`.
-- Risk: availability/usability rather than confidentiality; users cannot inspect large files via safe slice.
-- Recommended fix: when `line_start`/`line_end` is present, stream line-by-line up to requested range with byte budget.
+- Severity: Medium
+- Confidence: High
+- Surface: CLI/API auth options
+- Current mitigation: scoped auth stripping on cross-origin redirects and header
+  injection checks.
+- Risk: productizing private docs without allowlists, redaction, and audit logs
+  could leak sensitive content or credentials through outputs/logs.
+- Recommended fix: design explicit private-docs mode before promoting it:
+  allowlisted domains, scoped secrets, redaction, audit logs, privacy mode, and
+  strong output warnings.
 
-## v4.0.0 Security Claim Verification
+## Security Claim Verification
 
-- DNS-rebinding TOCTOU fix: Verified statically in `UrlValidator.resolve_allowed_addresses()` and `_ValidatedResolver`.
-- Wider SSRF coverage: Verified statically for CGNAT, IPv4-mapped IPv6, root-dot hostnames; TS MCP additionally blocks `nip.io`, `sslip.io`, `xip.io`.
-- robots.txt body cap: Verified in `RobotsChecker.MAX_ROBOTS_SIZE`.
-- YAML frontmatter injection fix: Verified in `FrontmatterBuilder._inline()` and list item quoting.
-- Conditional request header sanitization: Present by grep in `FetchStep`; runtime unverified due import failure.
-- Release/dependency hardening: Verified workflows and `requirements-release.txt` presence; `pip-audit` could not run due DNS.
+- URL validation and DNS pinning: verified by code and security tests.
+- Redirect revalidation/auth stripping: verified by tests.
+- robots/sitemap XML handling: verified by tests for robots behavior and XXE
+  sitemap rejection.
+- Frontmatter injection defenses: verified by conversion tests.
+- SQLite FTS: local-only output feature; search helper does not execute SQL
+  constructed from string interpolation.
+- Scraper API: thin wrapper around Fetcher, so it inherits the same URL/network
+  policy instead of adding a new fetch path.
+- Plugin cache path docs: checked against `default_docs_dir()` in CI policy
+  tests.

--- a/audit/04_TEST_PLAN.md
+++ b/audit/04_TEST_PLAN.md
@@ -2,58 +2,71 @@
 
 ## Current Inventory
 
-- Python source files: 60.
-- Python test files: 22.
-- Test definitions/classes counted by grep: 161.
-- Categories present: CLI, config, integration, discovery, link extractors, conversion, special cases, pipeline, chunking, cache conditional GET, MCP tools/server, security hardening, CI policy, real-site regressions, benchmark/performance, SQLite/NDJSON in dirty worktree.
+- Python source files: 73 checked by mypy.
+- Test suite: 522 tests passing in the current checkout.
+- Categories present: CLI, config, integration, discovery, link extractors,
+  conversion, special cases, pipeline, output formats, OKF, scraper API,
+  chunking, cache conditional GET, frontier/resume, MCP tools/server, security
+  hardening, CI policy, real-site regressions, benchmark/performance, pack
+  tools, provider workflows, SQLite, and NDJSON.
 
-## Baseline Results
+## Current Baseline Results
 
-- `pytest -q`: failed during collection with 11 errors, all rooted in `NameError: name 'FetchEvent' is not defined`.
-- `pytest --cov=src/docpull --cov-report=term-missing`: failed during collection for same reason.
-- `ruff check .`: failed with 11 issues, including `F821 Undefined name FetchEvent`, `F821 Undefined name SkipReason`, import sorting, line length, and unused import.
-- `mypy src/docpull`: failed with 3 errors in dirty worktree.
-- `bandit -r src/docpull`: found 8 low-severity `assert_used` findings; pyproject has a documented skip policy for B101 at `pyproject.toml:182-197`, but the local command did not pass `-c pyproject.toml`.
-- `pip-audit`: failed due DNS resolution to `pypi.org`.
+- `.venv/bin/pytest -q`: passed, 522 tests.
+- `.venv/bin/mypy src/docpull`: passed, 73 source files.
+- `.venv/bin/ruff check .`: passed.
+- `.venv/bin/python -m docpull --version`: passed, `docpull 4.2.0`.
+- `.venv/bin/python -m docpull --help`, `--doctor`, and `mcp --help`: passed.
+- `.venv/bin/pytest`, `.venv/bin/mypy`, and editable `docpull` console setup now
+  point at `/Users/mb1/Code/raintree/docpull` instead of the stale secondary
+  checkout.
+
+## Required Release Gate
+
+P0:
+
+- `.venv/bin/ruff check .`
+- `.venv/bin/mypy src/docpull`
+- `.venv/bin/pytest -q`
+- `.venv/bin/python -m docpull --version`
+- `.venv/bin/python -m docpull --help`
+- `.venv/bin/python -m docpull --doctor`
+- `.venv/bin/python -m docpull mcp --help`
 
 ## Missing or Weak Test Areas
 
-- CLI no-network smoke: import, `--version`, `--help`, `--doctor`, `mcp --help`.
-- Profile contract tests: `llm` strict JS behavior vs docs, mirror hierarchical naming expectation, quick profile page/depth caps.
-- Output format end-to-end tests: markdown, JSON, NDJSON, SQLite with small local server.
-- Cache/resume end-to-end tests: interrupted crawl, frontier persistence, stale fingerprint, output-dir deleted with cache retained.
-- Security edge tests: decompression bombs, root-dot hostnames in redirects, wildcard rebinding domains in Python validator, IPv4-mapped IPv6 redirects, symlinked output/cache directories, proxy + pinned DNS behavior.
-- MCP integration: all 8 tools through official client, including add/remove source, grep/read roundtrip, progress token, structured content validation.
-- Plugin bundle tests: `.claude-plugin` metadata, commands match tool names, cache path docs, slash command UX.
-- TypeScript MCP: semantic search disabled/enabled paths, DB migration tests, docpull child-process timeout, stale version field.
-- Performance tests runnable locally with opt-in env and summary artifact.
+- Plugin docs regression: cache path text matches `default_docs_dir()`.
+- Installed console-script smoke in CI after editable install.
+- SQLite FTS via CLI/MCP once a user-facing search command is added.
+- Manifest JSON Schema validation once schema file is added.
+- Framework fixtures now cover MkDocs/Material, VitePress, Astro/Starlight,
+  GitBook, ReadMe.io, and static Redoc/Scalar-style pages; live-regression
+  captures remain useful.
+- Security edge tests still valuable: decompression bombs, symlinked cache
+  directories, sitemap streaming caps, proxy + pinned DNS behavior in every
+  agent-facing path.
+- Optional JS renderer tests should be added only when that extra exists.
 
 ## Prioritized Regression Suite
 
 P0:
-- `tests/test_cli_smoke.py::test_version_imports_cleanly`
-- `tests/test_cli_smoke.py::test_help_imports_cleanly`
-- `tests/test_cli_smoke.py::test_doctor_imports_cleanly`
-- `tests/test_profiles.py::test_llm_profile_matches_documented_js_policy`
-- `tests/test_cli.py::test_cli_naming_strategy_choices_match_config_literal`
-- `tests/test_plugin_docs.py::test_plugin_readme_cache_path_matches_sources_default`
+
+- CLI import/no-network smoke for version/help/doctor/mcp help.
+- Output e2e for markdown/json/ndjson/sqlite/okf.
+- Scraper API one-page and site-write tests.
+- SQLite FTS creation, legacy backfill, and search helper tests.
+- Stable document/chunk ID tests.
+- Docusaurus/Sphinx static framework fixtures.
+- MkDocs, VitePress, Starlight, GitBook, ReadMe.io, and Redoc/Scalar static
+  framework fixtures.
 
 P1:
-- `tests/test_outputs_e2e.py::test_markdown_output_local_server`
-- `tests/test_outputs_e2e.py::test_json_output_schema_local_server`
-- `tests/test_outputs_e2e.py::test_ndjson_stream_stdout_flushes_per_page`
-- `tests/test_outputs_e2e.py::test_sqlite_output_schema_and_migration`
-- `tests/test_security_hardening.py::test_python_validator_blocks_wildcard_rebinding_domains_or_documents_allowance`
-- `tests/test_security_hardening.py::test_redirect_to_ipv4_mapped_private_ipv6_blocked`
-- `tests/test_security_hardening.py::test_proxy_with_require_pinned_dns_rejected`
-- `tests/test_security_hardening.py::test_oversized_sitemap_stream_aborts_before_full_read`
+
+- `docpull pack validate` once manifest schema exists.
+- MCP search integration if SQLite FTS becomes an MCP surface.
 
 P2:
-- `tests/test_framework_extractors.py::test_mkdocs_material_fixture`
-- `tests/test_framework_extractors.py::test_vitepress_fixture`
-- `tests/test_framework_extractors.py::test_starlight_fixture`
-- `tests/test_framework_extractors.py::test_gitbook_fixture`
-- `tests/test_framework_extractors.py::test_redoc_scalar_openapi_fixture`
-- `tests/test_mcp_server.py::test_all_tools_have_annotations_and_output_schemas`
-- `tests/test_mcp_server.py::test_progress_token_forwarding`
-- `mcp/src/server.test.ts::ensure_docs_times_out_child_process`
+
+- Live framework regression captures.
+- JS-only local fixture for the future optional renderer.
+- Authenticated/internal docs source-policy tests.

--- a/audit/05_DOCS_AND_DX_REVIEW.md
+++ b/audit/05_DOCS_AND_DX_REVIEW.md
@@ -2,43 +2,51 @@
 
 ## Accurate Claims
 
-- Install extras in README match `pyproject.toml` extras for `llm`, `trafilatura`, `mcp`, and `all`.
-- README accurately describes Python MCP 8-tool surface at `README.md:184-198`, matching `src/docpull/mcp/server.py:225-485`.
-- README security claims are mostly backed by code: SSRF, DNS pinning, XXE, CRLF, redirect auth stripping.
-- Website feature copy around zero-trust networking is backed by `UrlValidator` and `AsyncHttpClient`.
-- Changelog 4.0.0 security claims are substantially traceable to code.
+- README positions docpull as a browser-free scraper for static and
+  server-rendered pages, with documentation ingestion as the sharpest workflow.
+- `docs/scraping-boundary.md` clearly states non-goals: no default JS
+  execution, no bot-defense evasion, no proxy-rotation product, no hosted
+  scraping API.
+- README quickstart documents page graph scraping, `--single`, LLM NDJSON,
+  OKF, and mirror/cache workflows.
+- README framework table now matches implementation for Next.js, Mintlify,
+  OpenAPI, Docusaurus, Sphinx, MkDocs/Material, VitePress, Starlight, GitBook,
+  ReadMe.io, and Redoc/Scalar-style static pages.
+- README documents scraper-facing Python API (`scrape_one`, `Scraper`) and core
+  Fetcher API.
+- README and `docs/corpus-manifest.md` document stable IDs, content hashes,
+  output paths, and manifest purpose.
+- SQLite output now has documented FTS retrieval through
+  `search_sqlite_documents()`.
+- Security claims are backed by code/tests: SSRF controls, DNS pinning when no
+  proxy delegates DNS, XXE-safe sitemap parsing, CRLF/header guards, redirect
+  auth stripping, and path traversal checks.
 
-## Claim / Implementation Gaps
+## Remaining Docs / DX Gaps
 
-- README quickstart and CLI examples cannot currently run in dirty worktree due import failure.
-- LLM profile comment says "fail-loud on JS-only pages" in `profiles.py:47-48`, but config sets `strict_js_required=False` in `profiles.py:54-57`.
-- README advertises `docpull mcp` startup, but current worktree import failure blocks it.
-- CLI help still accepts `flat` and `short` naming aliases, contradicting changelog 3.0.0 removal and `OutputConfig` literal.
-- Plugin README says cache defaults to `docpull/docs`; implementation uses `docpull-mcp/docs`.
-- Plugin README prerequisite says `docpull --version` should print `2.5.0 or newer`; current package is `4.0.0`, so this is stale.
-- README claims root `mcp/` mirror exists publicly; unable to verify public repo.
-- Website says discovered URL list is persisted and crash resumes in `web/components/Features.tsx:18-20`; current worktree contains frontier code but runtime is broken, and public-release behavior needs clean verification.
+- Plugin README cache path and version prerequisite currently match
+  `src/docpull/mcp/sources.py`, with a regression check in `tests/test_ci_policy.py`.
+- Root TypeScript MCP must remain clearly internal/separate unless it becomes a
+  deliberate public product.
+- Authenticated/internal docs examples are still thin relative to the security
+  risk of scoped secrets and private content.
+- Optional provider workflows are broad; pack recipes are documented, but a
+  smaller "which workflow should I use?" page would reduce agent/user mistakes.
+- Console-script smoke should be part of release docs/checklist because stale
+  venv shebangs can break `.venv/bin/*` even when `python -m` works.
 
-## New User Friction
+## AI-Agent DX
 
-- If installing from this dirty source tree, every CLI command fails before help.
-- `python` command is absent on this macOS environment; docs use `python -m venv`, which may require `python3`.
-- Network-restricted environments cannot run `pip install -e ".[all,dev]"` because build isolation tries to resolve setuptools from PyPI.
-- `docpull --doctor` is intended as a diagnostic but is currently blocked by package import path in script execution.
-- SQLite output is accepted by CLI/config but barely documented.
-- Authenticated docs are supported in config/CLI, but safe usage examples and secret-scoping guidance are thin.
-
-## AI-Agent DX Friction
-
-- MCP tool docs are good, but plugin slash commands rely on accurate cache/source path docs.
-- `grep_docs` is regex-only; agents may choose brittle patterns and miss relevant content.
-- No stable manifest schema/chunk IDs, making regenerated corpora hard to diff or cite.
-- No explicit crawl budget explanation in MCP responses before fetching large sources.
+- Strong: `--single`, streamed NDJSON, manifests, source indexes, pack scoring,
+  MCP fetch/read/grep tools, and scraper-facing API names.
+- Improved: SQLite FTS gives local retrieval a path beyond regex-only markdown
+  scans.
+- Still needed: one unified retrieval story across Markdown cache, NDJSON packs,
+  SQLite FTS, and MCP tools.
 
 ## Packaging
 
 - `pyproject.toml` declares Python 3.10-3.14 and typed package via `py.typed`.
-- CI tests Python 3.10-3.13 but intentionally excludes 3.14 in `.github/workflows/ci.yml`.
-- Publish workflow uses tag-only trusted publishing and verifies tag matches `pyproject.toml`.
-- Actions are pinned to full SHAs in inspected workflows.
-- Issue template contact links still point to `raintree-ai/docpull`, not `raintree-technology/docpull`.
+- Editable install is verified locally against this checkout.
+- Final release gate should exercise `.venv/bin/ruff`, `.venv/bin/mypy`,
+  `.venv/bin/pytest`, and `python -m docpull` smoke commands.

--- a/audit/06_PERFORMANCE_REVIEW.md
+++ b/audit/06_PERFORMANCE_REVIEW.md
@@ -2,40 +2,51 @@
 
 ## Benchmarks Found
 
-- `tests/benchmarks/test_performance.py`: conversion, deduplication, pipeline, config, memory-oriented microbenchmarks.
-- `tests/benchmarks/test_10k_pages.py`: synthetic localhost 10,000-page benchmark.
-- `.github/workflows/benchmark.yml`: nightly/on-demand 10k benchmark, fails if peak RSS exceeds 200 MB or duplicate fraction is wrong.
-- README references a synthetic 10,000-page localhost site around `README.md:286`.
+- `tests/benchmarks/test_performance.py`: conversion, deduplication, pipeline,
+  config, and memory-oriented microbenchmarks.
+- `tests/benchmarks/test_10k_pages.py`: synthetic localhost 10,000-page
+  benchmark.
+- `.github/workflows/benchmark.yml`: nightly/on-demand benchmark workflow.
+- `docpull benchmark quick`: provider/core benchmark harness.
 
-## Benchmarks Run
+## Benchmarks / Gates Run In Current Pass
 
-No performance benchmark completed. `pytest` collection fails before benchmark execution due `FetchEvent` import error.
-
-Commands attempted:
-- `pytest -q`: 11 collection errors.
-- `pytest --cov=src/docpull --cov-report=term-missing`: 11 collection errors.
+- `.venv/bin/pytest -q`: passed, 522 tests.
+- `.venv/bin/mypy src/docpull`: passed, 73 source files.
+- Targeted output/retrieval/framework tests passed after adding SQLite FTS and
+  scraper API.
+- Full 10,000-page benchmark was not run in this interactive pass.
 
 ## Static Performance Observations
 
-- Async HTTP and streaming discovery are implemented at the architecture level.
-- NDJSON writer flushes every record in `src/docpull/pipeline/steps/save_ndjson.py:63-69`, good for streaming but potentially write-heavy for large crawls.
-- `grep_docs` reads each Markdown file into memory line lists in `src/docpull/mcp/tools.py:530-532`; acceptable for small docs, but not indexed and can be slow for large caches.
-- `read_doc` refuses files over 1 MB before reading, reducing accidental huge reads.
-- Sitemap and robots caps exist, but sitemap-specific cap is post-fetch.
-- Root TypeScript MCP uses pgvector and batch inserts under PostgreSQL bind limits in `mcp/src/db.ts:24-29` and `197-231`.
+- Async HTTP and streaming discovery are implemented.
+- NDJSON flushes every record, which is good for pipes and agents but can be
+  write-heavy for very large file-output runs.
+- SQLite output now creates/backfills `documents_fts`, making local retrieval
+  cheaper than file-by-file regex scans for SQLite users.
+- MCP `grep_docs` still scans Markdown files line-by-line; it should eventually
+  prefer an indexed store when available.
+- `read_doc` has a large-file guard.
+- Sitemap and robots caps exist, but sitemap-specific cap should be enforced
+  earlier in the HTTP read path.
 
 ## Scaling Concerns
 
-- Large documentation sets need persistent searchable index beyond regex scan.
-- NDJSON per-record flush can bottleneck on slow filesystems; batch flush option could improve throughput when not piping.
-- `countMarkdownFiles` and `rglob("*.md")` scans are repeated in MCP cache/index operations.
-- Streaming discovery/backpressure claims need runtime verification.
-- Cache/resume/frontier code in dirty worktree is not validated.
+- Large documentation sets need a unified retrieval layer across Markdown,
+  NDJSON, SQLite, and MCP.
+- NDJSON per-record flush can bottleneck on slow filesystems; a batch flush
+  option may help when not writing to stdout.
+- Repeated `rglob("*.md")` scans in MCP cache/index operations can become slow
+  on large caches.
+- Streaming discovery/backpressure should be covered by a routine benchmark
+  profile.
 
 ## Recommended Performance Work
 
-1. Restore runnable tests and run `DOCPULL_BENCHMARK_10K=1 pytest -v -s tests/benchmarks/test_10k_pages.py`.
-2. Add a 100-page and 1,000-page local benchmark that runs by default or in CI quick mode.
-3. Add MCP grep benchmark on synthetic large cache; compare regex scan vs SQLite FTS.
+1. Run `DOCPULL_BENCHMARK_10K=1 .venv/bin/pytest -v -s
+   tests/benchmarks/test_10k_pages.py` before a performance-focused release.
+2. Add a 100-page and 1,000-page benchmark that can run in CI quick mode.
+3. Add MCP grep vs SQLite FTS benchmark on synthetic large cache.
 4. Add memory assertions for sitemap/robots/body caps.
-5. Add optional batch flush for NDJSON file output while preserving stdout flush.
+5. Add optional batch flush for NDJSON file output while preserving stdout
+   flush semantics.

--- a/audit/07_EXPANSION_ROADMAP.md
+++ b/audit/07_EXPANSION_ROADMAP.md
@@ -1,109 +1,96 @@
 # Expansion Roadmap
 
-## P0: Correctness, Security, Documentation
+## P0: Release The Current Baseline Cleanly
 
-### Fix current import/type/lint blockers
+### Final gate current unreleased changes
 
-- User story: As a user, I can run `docpull --help` and `docpull --version` after installing from source.
-- Why now: Current dirty worktree is unusable.
-- Evidence: `FetchEvent` NameError in `src/docpull/models/events.py:131-140`; ruff/mypy failures.
-- Plan: add postponed annotations, import `SkipReason` where used, fix ruff/mypy issues.
-- Files: `models/events.py`, `pipeline/steps/convert.py`, `cache/frontier.py`, formatting.
-- Tests: CLI smoke, import smoke, full pytest.
-- Docs: none.
-- Risk: S.
-- Estimate: S.
-- Acceptance: `ruff check .`, `mypy src/docpull`, `pytest -q`, `docpull --help` pass.
+- User story: As a user, I can install the current checkout and run the CLI,
+  API, scraper facade, and output formats without local path drift.
+- Current state: editable install now points at `/Users/mb1/Code/raintree/docpull`;
+  tests/mypy pass; ruff import-order issue was fixed.
+- Files: package metadata, CLI, scraper API, output sinks, docs.
+- Tests: `.venv/bin/ruff check .`, `.venv/bin/mypy src/docpull`,
+  `.venv/bin/pytest -q`, CLI smoke.
+- Acceptance: all gates pass from the normal `.venv/bin/*` entry points.
 
-### Align LLM profile JS policy
+### Keep OKF output scoped and stable
 
-- User story: As an agent, I know whether LLM mode skips or fails JS-only pages.
-- Evidence: README/inline comment vs `strict_js_required=False`.
-- Plan: choose behavior; likely keep skip default for compatibility and update comment/README, or set true in v5.
-- Files: `profiles.py`, README, website, tests.
-- Tests: profile contract test.
-- Risk: behavior change if set true.
-- Estimate: S.
-- Acceptance: docs, comments, and config agree.
+- User story: As an agent/wiki user, I can generate an OKF bundle without
+  colliding with generated `index.md` files.
+- Current state: `--format okf` and `--profile okf` write OKF concept
+  frontmatter, safe `_root.md` / `_page.md` files, generated indexes, and
+  `corpus.manifest.json`.
+- Acceptance: OKF e2e tests pass and README warns users to write OKF to a
+  clean directory.
 
-### Fix CLI naming aliases
+### Keep scraper positioning precise
 
-- User story: As a CLI user, deprecated `flat/short` behavior is not accepted silently then rejected later.
-- Evidence: `cli.py:136-143`, `config.py:145-150`, changelog 3.0.0.
-- Plan: remove `flat/short` from argparse or map with clear error.
-- Tests: parser/config test.
-- Risk: low.
-- Estimate: S.
-- Acceptance: `docpull --help` only lists valid names.
+- User story: As a developer, I understand docpull's scraper scope before
+  choosing it over Scrapy, Crawlee, hosted extraction APIs, or trafilatura.
+- Current state: `docs/scraping-boundary.md` defines browser-free scope and
+  non-goals; `docpull.scraper` exposes thin scraper-native APIs over Fetcher.
+- Acceptance: docs and API tests demonstrate first-class scraper usage without
+  adding a second crawler engine.
 
-### Correct plugin docs
+## P1: Deepen The Agent-Context Product
 
-- User story: As a Claude Code user, I can find/delete the actual cache.
-- Evidence: plugin README path mismatch.
-- Plan: update cache path, version prerequisite, and direct URL wording.
-- Tests: docs lint.
-- Estimate: S.
+### SQLite and local retrieval
 
-## P1: High-Impact Low-Risk
+- User story: As an agent/RAG builder, I can search locally generated artifacts
+  without loading every file into memory.
+- Current state: SQLite output creates/backfills an FTS5 index and exposes
+  `search_sqlite_documents()`.
+- Next steps: add a CLI/MCP search surface that prefers SQLite FTS when present
+  and falls back to markdown grep.
 
-### Stable corpus manifest and chunk IDs
+### Corpus manifest schema validation
 
-- User story: As a RAG builder, I can diff and cite regenerated docs reliably.
-- Code seam: `DocumentRecord`, `RunIdentity`, `NdjsonSaveStep`, `SqliteSaveStep`.
-- Plan: add `manifest.json`, stable chunk IDs from URL+heading+chunk index+content hash.
-- Tests: deterministic rerun tests.
-- Docs: output schema page.
-- Estimate: M.
+- User story: As a downstream consumer, I can validate pack/manifests before
+  indexing them.
+- Current state: manifests include stable IDs, content hashes, output paths,
+  chunk provenance, counts, and run identity; schema is documented in
+  `docs/corpus-manifest.md`.
+- Next steps: add JSON Schema and a `docpull pack validate` command.
 
-### SQLite FTS search path
+### Framework fixture expansion
 
-- User story: As an agent, I can search cached docs faster than regex scan without Postgres.
-- Code seam: `save_sqlite.py`, MCP `grep_docs`.
-- Plan: create SQLite FTS5 index; add optional MCP source `search_docs` or faster grep.
-- Tests: FTS ranking, migration, path validation.
-- Estimate: M.
+- User story: As a user, common docs frameworks are handled predictably without
+  requiring JavaScript rendering.
+- Current state: fixtures cover Next.js, Mintlify, OpenAPI, raw text,
+  Docusaurus, Sphinx, MkDocs/Material, VitePress, Astro/Starlight, GitBook,
+  ReadMe.io, and static Redoc/Scalar-style API reference pages.
+- Next targets: live-regression captures and deeper framework-specific data
+  feeds where static extraction underperforms.
 
-### Per-project MCP cache
+### Plugin/MCP cache clarity
 
-- User story: As a team, each repo has its own docs snapshot.
-- Code seam: `default_docs_dir()`, plugin config, commands.
-- Plan: support `.docpull/docs` or env/config override in plugin commands.
-- Tests: XDG/env/project precedence.
-- Estimate: M.
-
-### Framework extractor fixture suite
-
-- User story: As a user, DocPull handles common docs frameworks predictably.
-- Targets: MkDocs/Material, VitePress, VuePress, Astro/Starlight, GitBook, ReadMe.io, Redoc/Scalar.
-- Code seam: `conversion/special_cases.py`.
-- Plan: add local HTML fixtures before live extractors.
-- Tests: one fixture per framework.
-- Estimate: M.
+- User story: As a Claude Code or MCP user, I can find, refresh, and delete the
+  actual cache location.
+- Current state: `plugin/README.md` points to `docpull-mcp/docs`, matching
+  `src/docpull/mcp/sources.py`, and `tests/test_ci_policy.py` checks the
+  README path/version text.
 
 ## P2: Strategic Expansion
 
 ### Optional JS rendering adapter
 
 - User story: As a user, JS-only docs can be fetched when I explicitly opt in.
-- Plan: keep browser-free default; add Playwright/Browserless adapter behind extra and strict domain/budget controls.
+- Plan: keep browser-free default; add Playwright/Browserless behind a separate
+  extra, domain allowlists, page/request budgets, and local JS-only fixtures.
 - Risk: security, cost, flakiness.
-- Estimate: L.
-- Acceptance: JS-only local fixture succeeds only with adapter enabled.
 
 ### Authenticated/internal docs mode
 
 - User story: As an enterprise user, I can fetch private docs safely.
-- Plan: allowlist domains, scoped headers/cookies, redaction, audit log, no cross-origin auth, privacy mode.
-- Files: config, HTTP, docs, MCP tools.
+- Plan: allowlist domains, scoped headers/cookies, redaction, audit log,
+  cross-origin auth stripping, and privacy mode.
 - Risk: high.
-- Estimate: L/XL.
 
 ### Semantic search product path
 
 - User story: As an agent, I can ask conceptual questions over cached docs.
-- Plan: decide whether root `mcp/` becomes official or Python MCP gains optional embeddings adapters.
-- Dependencies: OpenAI/local embeddings/vector DB.
-- Estimate: L.
+- Plan: decide whether Python MCP gains optional embeddings adapters or whether
+  the root TypeScript MCP remains a separate/internal experiment.
 
 ## P3: Speculative Bets
 

--- a/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
+++ b/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
@@ -1,16 +1,25 @@
 # Claim / Implementation Gaps
 
-| Claim | Source | Actual Evidence | Status | Fix |
-|---|---|---|---|---|
-| Current runtime supports CLI help/version/doctor | README quickstart and CLI docs | Current worktree commands fail importing `FetchEvent` | Broken | Fix annotation/import blocker and add smoke tests |
-| LLM profile is fail-loud on JS-only pages | `profiles.py:47-48` comment and README agent positioning | `strict_js_required=False` at `profiles.py:54-57` | Gap | Align docs/comment/config |
-| `flat`/`short` naming aliases removed in 3.0 | `docs/CHANGELOG.md:118-120` | CLI still accepts them at `cli.py:136-143`; config rejects them | Gap | Remove from CLI choices |
-| Plugin cache path is `$XDG_DATA_HOME/docpull/docs` | `plugin/README.md:63-65` | Python MCP uses `docpull-mcp/docs` at `sources.py:114-120` | Gap | Update plugin README |
-| Plugin prerequisite should print `2.5.0 or newer` | `plugin/README.md:27` | Package is 4.0.0; plugin metadata version 0.2.0 | Stale | Update prerequisite/version docs |
-| Root `mcp/` mirrored to public `docpull-mcp` repo | `README.md:211-219`, `mcp/package.json:35-38` | Public mirror not verified in browser/search | Unverified | Make repo public or mark private/unavailable |
-| TypeScript MCP server version is 0.3.0 | `mcp/package.json:2-3` | `mcp/src/server.ts:396` says version `0.2.0` | Gap | Single-source version |
-| Website says discovered URL list is persisted for crash resume | `web/components/Features.tsx:18-20` | Dirty worktree has `frontier.py`, but import failure blocks verification | Unverified/Broken | Stabilize frontier and add e2e resume test |
-| Sphinx detected/tagged | `README.md:64-65` | No directly inspected Sphinx extractor evidence in `special_cases.py` snippet | Unverified | Add explicit Sphinx test/code reference or remove claim |
-| Production/stable classifier | `pyproject.toml:24-27` | Dirty worktree is not runnable | Gap for current workspace | Do not release until clean gates pass |
-| All tools with data return structuredContent | `README.md:198` | Implemented for most tools; `fetch_url` intentionally has no output schema | Mostly accurate | Wording should say all schema-backed tools |
-| Website/product says production-grade ingestion | `web/components/Features.tsx:37-39` | Strong design, but current worktree broken | Gap for current workspace | Ship patch after gates |
+## Resolved In Current Worktree
+
+| Claim / gap | Current evidence | Status |
+| --- | --- | --- |
+| Runtime supports CLI help/version | `.venv/bin/python -m docpull --version` reports `docpull 4.2.0`; help works through the same import path | Resolved |
+| Local editable install points at this checkout | `.venv/bin/python -m pip show docpull` reports editable project location `/Users/mb1/Code/raintree/docpull` | Resolved |
+| `flat`/`short` naming aliases removed in 3.0 | CLI help now lists only `full` and `hierarchical`; config allows only those literals | Resolved |
+| LLM profile JS policy is ambiguous | `profiles.py` documents that LLM mode skips JS-only pages by default; `--strict-js-required` remains the explicit fail-loud option | Resolved |
+| Sphinx detected/tagged claim was weak | Sphinx now has an explicit static body extractor fixture and returns `source_type="sphinx"` | Resolved |
+| Docusaurus detected/tagged claim was weak | Docusaurus now has an explicit static article extractor fixture and returns `source_type="docusaurus"` | Resolved |
+| Common docs frameworks lacked fixture coverage | Static-region fixtures now cover MkDocs/Material, VitePress, Starlight, GitBook, ReadMe.io, and Redoc/Scalar-style pages | Resolved |
+| SQLite output lacks local retrieval | `documents_fts` is created/backfilled and `search_sqlite_documents()` returns FTS hits | Resolved |
+| Product boundary around "scraper" is implicit | `docs/scraping-boundary.md` defines browser-free scope and non-goals | Resolved |
+| Plugin cache path/version docs drifted | `plugin/README.md` now points to `$XDG_DATA_HOME/docpull-mcp/docs/` / `~/.local/share/docpull-mcp/docs/` and says `4.0.0 or newer` | Resolved |
+
+## Still Open
+
+| Claim / gap | Current evidence | Status | Fix |
+| --- | --- | --- | --- |
+| Root TypeScript MCP status can confuse users | Python MCP is the package-supported path; root `mcp/` is separate/internal | Open architecture/documentation risk | Keep end-user docs focused on Python MCP or deliberately split/rename the TS surface |
+| Optional JS rendering is expected by some "web scraper" users | README and boundary docs say browser-free default | Open strategic feature | Only add behind a separate extra with domain/budget controls |
+| Authenticated/internal docs need stronger policy | Auth headers exist, but enterprise/private-doc mode is not a designed product surface | Open strategic feature | Add allowlists, redaction, audit logs, and scoped secret handling before marketing it |
+| Live framework regressions remain valuable | Static fixtures cover common frameworks, but live pages can drift | Open feature work | Add curated live-regression captures and deeper data-feed extractors where static extraction underperforms |

--- a/audit/09_ISSUE_BACKLOG.md
+++ b/audit/09_ISSUE_BACKLOG.md
@@ -2,104 +2,84 @@
 
 ## P0
 
-### Import failure blocks all CLI/API/MCP use
+### Final release gate for current unreleased changes
 
-- Labels: `bug`, `tests`, `dx`
-- Severity: critical
-- Evidence: `src/docpull/models/events.py:131-140`; command failures.
-- Repro: `./.venv/bin/docpull --version`.
-- Expected: `docpull 4.0.0`.
-- Actual: `NameError: name 'FetchEvent' is not defined`.
-- Fix: postponed annotations or quoted return type; add smoke tests.
-
-### Ruff/mypy failures in dirty worktree
-
-- Labels: `bug`, `tests`, `dx`
+- Labels: `tests`, `release`, `dx`
 - Severity: high
-- Evidence: ruff F821 for `FetchEvent` and `SkipReason`; mypy 3 errors.
-- Repro: `ruff check .`; `mypy src/docpull`.
-- Fix: imports/annotations/typing cleanup.
-
-### LLM profile docs disagree with behavior
-
-- Labels: `docs`, `bug`
-- Severity: medium
-- Evidence: `profiles.py:47-57`.
-- Fix: align config/docs/comment.
-
-### CLI accepts removed naming aliases
-
-- Labels: `bug`, `dx`, `docs`
-- Severity: medium
-- Evidence: `cli.py:136-143`, `config.py:145-150`, changelog 3.0.0.
-- Fix: remove or explicitly reject aliases.
-
-### Plugin README cache path is wrong
-
-- Labels: `plugin`, `docs`, `dx`
-- Severity: medium
-- Evidence: `plugin/README.md:63-65`, `mcp/sources.py:114-120`.
-- Fix: update docs and add regression check.
+- Evidence: Current worktree adds OKF output, scraper API, SQLite FTS,
+  framework extractors, docs, and audit updates.
+- Fix: before release, run `.venv/bin/ruff check .`, `.venv/bin/mypy
+  src/docpull`, `.venv/bin/pytest -q`, `.venv/bin/python -m docpull --help`,
+  `.venv/bin/python -m docpull --version`, and `.venv/bin/python -m docpull
+  --doctor`.
 
 ## P1
+
+### Add framework fixture extractors
+
+- Labels: `feature`, `tests`, `scraping`
+- Severity: medium
+- Completed now: Docusaurus, Sphinx, MkDocs/Material, VitePress, Starlight,
+  GitBook, ReadMe.io, and Redoc/Scalar-style static extraction fixtures.
+- Remaining target: curated live-regression captures and deeper data-feed
+  extractors only where static extraction underperforms.
+
+### Add CLI no-network smoke tests for installed entry points
+
+- Labels: `tests`, `dx`
+- Severity: high
+- Evidence: A stale venv shebang previously broke direct `pytest`/`mypy`
+  scripts even when `python -m` worked.
+- Fix: test installed entry points in CI or add a local release checklist that
+  exercises console scripts after editable install.
+
+### Improve SQLite search surface
+
+- Labels: `feature`, `retrieval`, `mcp`
+- Severity: medium
+- Current state: SQLite output creates/backfills FTS5 and exposes
+  `search_sqlite_documents()`.
+- Next step: add CLI or MCP search over `documents.db` when a source has SQLite
+  output, with markdown fallback for normal docs caches.
+
+### Strengthen corpus manifest validation
+
+- Labels: `feature`, `architecture`, `tests`
+- Severity: medium
+- Current state: manifests record stable IDs, hashes, output paths, counts, run
+  identity, and chunk provenance; schema documented in `docs/corpus-manifest.md`.
+- Next step: add a JSON Schema or stricter pack validation command.
 
 ### Verify and document root TypeScript MCP status
 
 - Labels: `mcp`, `architecture`, `docs`
 - Severity: medium
-- Evidence: README mirror claim unverified; TS/Python MCP duplicate tools.
-- Fix: split/private/experimental decision and README update.
-
-### Add CLI no-network smoke tests
-
-- Labels: `tests`, `dx`
-- Severity: high
-- Evidence: current import failure escaped.
-- Fix: test `--version`, `--help`, `--doctor`, `mcp --help`.
-
-### Add output format e2e suite
-
-- Labels: `tests`, `feature`
-- Severity: medium
-- Evidence: formats claimed; runtime not verified.
-- Fix: localhost fixture for markdown/json/ndjson/sqlite.
-
-### Add proxy-mode security tests/docs
-
-- Labels: `security`, `tests`, `docs`
-- Severity: medium
-- Evidence: proxy disables resolver pinning by design.
-- Fix: tests and explicit agent guidance.
-
-### Add SQLite/FTS or indexed grep
-
-- Labels: `performance`, `mcp`, `feature`
-- Severity: medium
-- Evidence: MCP grep scans files line-by-line.
-- Fix: optional FTS index.
+- Evidence: Python MCP is the supported package path; root `mcp/` remains a
+  separate/internal surface.
+- Fix: keep end-user docs focused on Python MCP unless the TS surface is split
+  into its own public product.
 
 ## P2
-
-### Add framework fixture extractors
-
-- Labels: `feature`, `tests`
-- Severity: medium
-- Targets: MkDocs, VitePress, VuePress, Starlight, GitBook, ReadMe.io, Redoc/Scalar.
-
-### Add corpus manifest and stable chunk IDs
-
-- Labels: `feature`, `architecture`
-- Severity: medium
-- Fix: manifest schema, source maps, deterministic chunk IDs.
-
-### Authenticated/internal docs mode
-
-- Labels: `feature`, `security`
-- Severity: high
-- Fix: allowlists, scoped secrets, redaction, audit logs.
 
 ### Optional JS renderer
 
 - Labels: `feature`, `security`, `performance`
 - Severity: strategic
-- Fix: Playwright/Browserless adapter behind explicit extra and policy.
+- Fix: keep browser-free default; add Playwright/Browserless only behind an
+  explicit extra, domain allowlists, request/page budgets, and local JS-only
+  fixture tests.
+
+### Authenticated/internal docs mode
+
+- Labels: `feature`, `security`
+- Severity: high
+- Fix: design allowlists, scoped auth headers/cookies, redaction, audit logs,
+  privacy mode, and no cross-origin auth before promoting this as a product
+  mode.
+
+### Pack and MCP retrieval improvements
+
+- Labels: `mcp`, `retrieval`, `feature`
+- Severity: medium
+- Fix: unify markdown grep, NDJSON records, SQLite FTS, and pack source maps
+  into a predictable local retrieval layer for agents.

--- a/audit/10_AGENT_CONTEXT_BRIEF.md
+++ b/audit/10_AGENT_CONTEXT_BRIEF.md
@@ -1,30 +1,49 @@
 # Agent Context Brief
 
-DocPull is a Python 3.10+ package/CLI at version 4.0.0. It fetches static docs over async HTTP, validates URLs, respects robots.txt, converts to Markdown/JSON/NDJSON/SQLite-style records, and ships a Python stdio MCP server. The repo also contains a separate Bun/TypeScript `mcp/` semantic-search MCP with Postgres/pgvector and a Claude Code plugin.
+DocPull is a Python 3.10+ package/CLI at version 4.2.0. It is a browser-free
+web scraper for static/server-rendered docs and pages, with agent-context output
+formats: Markdown, JSON, NDJSON, SQLite, OKF, manifests, source indexes, and
+MCP tools. The repo also contains optional Parallel provider workflows, a
+Claude Code plugin, a website, and a separate/internal Bun/TypeScript MCP lab.
 
-Current workspace is dirty and broken. Do not assume it represents clean public 4.0.0. `docpull --version`, `--help`, `--doctor`, `pytest`, and coverage all fail because `src/docpull/models/events.py` references `FetchEvent` in a return annotation before the class exists. Fix this before any feature work.
+Current workspace is dirty but functional. The dirty work adds unreleased OKF
+output, a scraper-facing API, SQLite FTS search, Docusaurus/Sphinx fixture
+extractors, manifest/schema docs, and audit cleanup. Do not treat these changes
+as released until the final gate passes from normal `.venv/bin/*` entry points.
 
-Core flow: CLI -> `DocpullConfig` -> `Fetcher` -> `UrlValidator`/`RobotsChecker`/`AsyncHttpClient` -> sitemap/link discovery -> `FetchPipeline` -> validate/fetch/convert/metadata/dedup/chunk/save.
+Core flow: CLI / scraper API / Python API / MCP -> `DocpullConfig` -> `Fetcher`
+-> `UrlValidator` / `RobotsChecker` / `AsyncHttpClient` -> sitemap/link
+discovery -> `FetchPipeline` -> validate/fetch/convert/metadata/dedup/chunk/save.
 
-Security model: HTTPS-only, private/internal/localhost/CGNAT/IPv4-mapped IPv6 blocks, DNS root-dot stripping, connect-time DNS pinning via aiohttp resolver, redirect revalidation, cross-origin auth stripping, robots pinned fetch, defusedxml for sitemap XML, YAML frontmatter sanitization, MCP path and regex guards.
+Security model: HTTPS-only default, private/internal/localhost/CGNAT and
+IPv4-mapped IPv6 blocks, DNS root-dot stripping, connect-time DNS pinning when
+not using a proxy, redirect revalidation, cross-origin auth stripping, robots
+handling, defusedxml for sitemap XML, YAML frontmatter sanitization, MCP path
+guards, and regex timeouts.
 
-Highest-priority gaps:
-- Fix import/lint/type/test failures.
-- Align LLM profile JS-only behavior with docs.
-- Remove CLI `flat`/`short` naming aliases or update config/docs.
-- Fix plugin cache path docs: implementation uses `~/.local/share/docpull-mcp/docs`.
-- Decide/document root TypeScript MCP status; public mirror claim is unverified.
+Current highest-priority checks:
 
-Useful commands after fixing import blocker:
+- Keep `.venv/bin/ruff check .`, `.venv/bin/mypy src/docpull`, and
+  `.venv/bin/pytest -q` green.
+- Smoke `.venv/bin/python -m docpull --version`, `--help`, `--doctor`, and
+  `mcp --help` before release.
+- Keep plugin README cache path/version regression green.
+- Keep scraper positioning narrow: local, auditable, browser-free
+  web-to-context extraction, not general browser automation.
+- Add new framework support fixture-first.
+
+Useful commands:
 
 ```bash
-./.venv/bin/docpull --version
-./.venv/bin/docpull --help
-./.venv/bin/docpull --doctor
-./.venv/bin/pytest -q
-./.venv/bin/ruff check .
-./.venv/bin/mypy src/docpull
-./.venv/bin/bandit -q -c pyproject.toml -r src
+.venv/bin/python -m docpull --version
+.venv/bin/python -m docpull --help
+.venv/bin/python -m docpull --doctor
+.venv/bin/python -m docpull mcp --help
+.venv/bin/pytest -q
+.venv/bin/ruff check .
+.venv/bin/mypy src/docpull
+.venv/bin/bandit -q -c pyproject.toml -r src
 ```
 
-Do not run uncontrolled crawls. Use localhost fixtures and `--single` / `--max-pages`.
+Do not run uncontrolled crawls. Use localhost fixtures, `--single`,
+`--max-pages`, and `--dry-run` / `--preview-urls` when exploring behavior.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add first-class Open Knowledge Format output via `--format okf` and
+  `--profile okf`, including OKF concept frontmatter, generated directory
+  `index.md` files with root `okf_version: "0.1"`, and docpull corpus
+  manifests.
+- Add the `docpull.scraper` API surface (`Scraper`, `scrape_one`,
+  `scrape_site`, and `ScrapeResult`) as thin scraper-native names over the
+  existing browser-free Fetcher pipeline.
+- Add `docs/scraping-boundary.md` to define docpull as a local, auditable
+  static/server-rendered web-to-context scraper rather than a general browser
+  automation framework.
+- Add SQLite FTS5 indexing for `--format sqlite` output plus
+  `search_sqlite_documents()` for local full-text retrieval.
+- Add static Docusaurus, Sphinx, MkDocs/Material, VitePress, Starlight,
+  GitBook, ReadMe.io, and Redoc/Scalar-style extraction fixtures so common
+  docs frameworks are extracted and tagged without JavaScript rendering.
+
 ## [4.2.0] - 2026-06-08
 
 ### Added

--- a/docs/corpus-manifest.md
+++ b/docs/corpus-manifest.md
@@ -1,0 +1,52 @@
+# Corpus Manifest
+
+Every docpull output sink writes `corpus.manifest.json` next to generated
+artifacts. The manifest is the stable source map for a crawl: it lets agents,
+RAG jobs, pack diff tools, and audits connect records back to URLs and files
+without reparsing every output format.
+
+## Top-level fields
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Manifest schema version. Current value: `1`. |
+| `generated_at` | UTC timestamp when the manifest was written. |
+| `output_format` | Output sink that produced the records: `markdown`, `json`, `ndjson`, `sqlite`, or `okf`. |
+| `run` | Stable, non-secret run identity derived from profile, crawl, output, extractor, and JS policy settings. |
+| `document_count` | Unique logical document count. |
+| `record_count` | Total emitted records. For chunked output this may exceed `document_count`. |
+| `chunk_count` | Number of records with `chunk_id`. |
+| `records` | Ordered record source map. |
+
+## Record fields
+
+Each `records[]` entry may include:
+
+| Field | Meaning |
+| --- | --- |
+| `document_id` | Stable ID derived from URL and content hash. |
+| `url` | Original source URL. |
+| `title` | Extracted title when available. |
+| `source_type` | Detected/extracted source type such as `next_data`, `openapi`, `docusaurus`, or `sphinx`. |
+| `content_hash` | SHA-256 hash of the emitted content field/body. For Markdown and OKF, this includes frontmatter added by that sink. For JSON, NDJSON, and SQLite, record metadata fields are not part of this hash. |
+| `output_path` | Path to the generated artifact relative to the output directory, or `"-"` for NDJSON records streamed to stdout. |
+| `chunk_id` | Stable chunk ID derived from URL, chunk index, heading, and chunk content hash. |
+| `chunk_index` | Zero-based chunk position within the source page. |
+| `chunk_heading` | Heading context captured by the chunker. |
+| `token_count` | Token count or estimate for chunked records. |
+
+## Stability contract
+
+- `document_id` is stable for identical URL and emitted content.
+- `document_id` changes when emitted content changes.
+- `chunk_id` is stable for identical URL, chunk index, chunk heading, and emitted
+  chunk content.
+- `content_hash` describes the emitted content body, including frontmatter when
+  the sink adds it. It is not a hash of the surrounding JSON/SQLite record
+  envelope.
+- File-backed `output_path` values are relative so packs can move between
+  machines. NDJSON stdout records use `"-"`.
+- The manifest does not include secrets or auth headers.
+
+Consumers should treat unknown fields as forward-compatible metadata and should
+gate strict validation on `schema_version`.

--- a/docs/scraping-boundary.md
+++ b/docs/scraping-boundary.md
@@ -1,0 +1,57 @@
+# Scraping Boundary
+
+docpull is a browser-free web scraper for turning static and server-rendered
+web pages into local, auditable context artifacts. Its sharpest workflow is
+documentation ingestion for agents, RAG systems, offline archives, and source
+packs.
+
+## What docpull should do
+
+- Fetch HTTPS pages with async HTTP, URL validation, DNS pinning, redirect
+  revalidation, robots.txt compliance, and rate limits.
+- Crawl known page graphs through sitemaps and static links.
+- Convert server-rendered HTML, raw Markdown/text, OpenAPI specs, and common
+  docs frameworks into clean Markdown.
+- Emit local artifacts that agents can inspect: Markdown, JSON, NDJSON, SQLite,
+  OKF bundles, manifests, source indexes, and MCP-readable docs.
+- Preserve provenance with source URLs, stable document/chunk IDs, content
+  hashes, extraction metadata, and reproducible manifests.
+
+## What docpull should not do by default
+
+- Execute JavaScript for every page.
+- Evade bot defenses, solve CAPTCHA challenges, or rotate residential proxies.
+- Become a Scrapy-style programmable spider framework.
+- Become a hosted scraping API.
+- Send scraped content to third-party services unless the user explicitly opts
+  into a provider workflow.
+
+## JavaScript boundary
+
+docpull detects JS-only pages and skips them with a clear reason, or fails loud
+when `--strict-js-required` is set. Optional rendering can be added later only
+behind a separate extra, explicit domain/budget controls, and tests proving the
+browser-free default remains unchanged.
+
+## When to use another tool
+
+- Use Scrapy when you need a programmable spider framework with custom item
+  pipelines.
+- Use Crawlee when browser automation, sessions, queues, and anti-blocking
+  workflows are the core job.
+- Use a hosted extraction service when you want managed rendering, proxies, and
+  external infrastructure.
+- Use trafilatura directly when you only need article text extraction and do
+  not need docpull's crawler, security posture, output manifests, or agent
+  pack formats.
+
+## Worthwhile expansion
+
+The product should deepen the local agent-ingestion lane:
+
+- More docs-framework fixtures and extractors.
+- Better local search over generated artifacts.
+- Stable corpus schemas, source maps, and chunk provenance.
+- Pack scoring, diffing, and refresh workflows.
+- Explicit authenticated/internal docs mode only after source policy, redaction,
+  and audit logging are designed.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # docpull plugin for Claude Code
 
-Pull docs from any URL into Claude Code. Local, fast, no API keys.
+Pull static and server-rendered docs into Claude Code. Local, fast, no API keys.
 
 ## What you get
 

--- a/plugin/skills/docpull-research/SKILL.md
+++ b/plugin/skills/docpull-research/SKILL.md
@@ -47,7 +47,7 @@ If you want more context around a hit, use `read_doc(library, path, line_start, 
 ### 3. If the library is NOT cached → decide whether to fetch
 
 - **Built-in alias** (the library appears in `list_sources()`): call `ensure_docs(source="<alias>")`. This crawls and indexes the whole library. ~10–30s for typical sites.
-- **Arbitrary URL**: call `fetch_url(url=...)` if you only need one page. For a whole site you don't have an alias for, tell the user to run `/docs-add <URL>` (which uses the docpull CLI to crawl); the MCP `fetch_url` is single-page only.
+- **Pasted docs URL**: call `fetch_url(url=...)` if you only need one static/server-rendered page. For a whole docs site you don't have an alias for, tell the user to run `/docs-add <URL>` (which uses the docpull CLI to crawl); the MCP `fetch_url` is single-page only.
 - **No alias, user didn't paste a URL**: ask the user once whether they'd like to add the library, and what the docs URL is. Don't fetch speculatively.
 
 ### 4. Quote with attribution

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -1,5 +1,5 @@
 """
-docpull - Fetch and convert documentation from any URL to markdown.
+docpull - Fetch and convert static/server-rendered documentation to markdown.
 
 Usage:
     from docpull import Fetcher, DocpullConfig, ProfileName
@@ -31,12 +31,27 @@ from .models.config import (
 )
 from .models.events import EventType, FetchEvent, FetchStats
 from .pipeline.base import PageContext
+from .pipeline.steps import SqliteSearchResult, search_sqlite_documents
+from .scraper import (
+    Scraper,
+    ScrapeResult,
+    ScrapeRunResult,
+    scrape_one,
+    scrape_one_blocking,
+    scrape_site,
+)
 
 __all__ = [
     "__version__",
     "Fetcher",
     "fetch_blocking",
     "fetch_one",
+    "ScrapeResult",
+    "ScrapeRunResult",
+    "Scraper",
+    "scrape_one",
+    "scrape_one_blocking",
+    "scrape_site",
     "PageContext",
     "DocpullConfig",
     "ProfileName",
@@ -49,6 +64,8 @@ __all__ = [
     "EventType",
     "FetchEvent",
     "FetchStats",
+    "SqliteSearchResult",
+    "search_sqlite_documents",
     "CacheManager",
     "StreamingDeduplicator",
     "Chunk",

--- a/src/docpull/cli.py
+++ b/src/docpull/cli.py
@@ -48,7 +48,7 @@ def create_parser() -> argparse.ArgumentParser:
     """Create argument parser for CLI."""
     parser = argparse.ArgumentParser(
         prog="docpull",
-        description="Fetch and convert documentation from any URL to markdown",
+        description="Fetch and convert static/server-rendered documentation to markdown",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -87,9 +87,9 @@ Examples:
     parser.add_argument(
         "--profile",
         "-p",
-        choices=["rag", "mirror", "quick", "llm"],
+        choices=["rag", "mirror", "quick", "llm", "okf"],
         default="rag",
-        help="Preset profile (default: rag). 'llm' bundles chunking + NDJSON + rich metadata.",
+        help="Preset profile (default: rag). 'llm' streams chunked NDJSON; 'okf' writes an OKF bundle.",
     )
 
     parser.add_argument(
@@ -125,9 +125,9 @@ Examples:
     parser.add_argument(
         "--format",
         "-f",
-        choices=["markdown", "json", "ndjson", "sqlite"],
+        choices=["markdown", "json", "ndjson", "sqlite", "okf"],
         default=None,
-        help="Output format (default: markdown; 'ndjson' streams one record per line)",
+        help="Output format (default: markdown; 'ndjson' streams records; 'okf' writes an OKF bundle)",
     )
     parser.add_argument(
         "--naming-strategy",
@@ -383,8 +383,17 @@ def run_fetcher(args: argparse.Namespace) -> int:
         "mirror": ProfileName.MIRROR,
         "quick": ProfileName.QUICK,
         "llm": ProfileName.LLM,
+        "okf": ProfileName.OKF,
     }
     profile = profile_map.get(args.profile, ProfileName.RAG)
+
+    requested_format = args.format or ("okf" if args.profile == "okf" else None)
+    if args.skill and requested_format == "okf":
+        console.print(
+            "[red]Error:[/red] --skill cannot be combined with OKF output. "
+            "Write OKF with --format okf, or generate a skill with markdown output."
+        )
+        return 1
 
     config_kwargs: dict = {
         "profile": profile,

--- a/src/docpull/conversion/markdown.py
+++ b/src/docpull/conversion/markdown.py
@@ -514,3 +514,53 @@ class FrontmatterBuilder:
 
         lines.append("---")
         return "\n".join(lines) + "\n\n"
+
+    def build_okf(
+        self,
+        *,
+        concept_type: str = "Documentation Page",
+        title: str | None = None,
+        resource: str | None = None,
+        description: str | None = None,
+        tags: list[str] | None = None,
+        timestamp: str | None = None,
+        source: str | None = None,
+        **extra_fields: Any,
+    ) -> str:
+        """Build Open Knowledge Format concept frontmatter."""
+        lines = ["---", f"type: {self._quoted(concept_type)}"]
+
+        if title:
+            lines.append(f"title: {self._quoted(title)}")
+
+        if description:
+            lines.append(f"description: {self._quoted(description[:500])}")
+
+        if resource:
+            lines.append(f"resource: {self._inline(resource)}")
+
+        if tags:
+            lines.append("tags:")
+            for tag in tags:
+                lines.append(f"  - {self._quoted(tag)}")
+
+        if timestamp:
+            lines.append(f"timestamp: {self._inline(timestamp)}")
+
+        if source:
+            # docpull extension retained for compatibility with existing consumers.
+            lines.append(f"source: {self._inline(source)}")
+
+        for key, value in extra_fields.items():
+            if value is not None:
+                if isinstance(value, str):
+                    lines.append(f"{key}: {self._quoted(value)}")
+                elif isinstance(value, (list, tuple)):
+                    lines.append(f"{key}:")
+                    for item in value:
+                        lines.append(f"  - {self._quoted(item)}")
+                else:
+                    lines.append(f"{key}: {self._inline(value)}")
+
+        lines.append("---")
+        return "\n".join(lines) + "\n\n"

--- a/src/docpull/conversion/special_cases.py
+++ b/src/docpull/conversion/special_cases.py
@@ -67,6 +67,15 @@ def _soup(html: bytes) -> BeautifulSoup:
     return BeautifulSoup(_decode_html(html), "html.parser")
 
 
+def _hostname_from_url(url: str) -> str:
+    return (urlparse(url).hostname or "").lower().rstrip(".")
+
+
+def _hostname_matches_domain(hostname: str, domain: str) -> bool:
+    normalized_domain = domain.lower().rstrip(".")
+    return hostname == normalized_domain or hostname.endswith(f".{normalized_domain}")
+
+
 def _title_from_soup(soup: BeautifulSoup) -> str | None:
     if soup.title and soup.title.string:
         title = soup.title.string.strip()
@@ -244,11 +253,15 @@ class StaticRegionFrameworkExtractor:
     name = "static_framework"
     framework = "static"
     markers: tuple[bytes, ...] = ()
+    host_domains: tuple[str, ...] = ()
     selectors: tuple[str, ...] = ("article", "main")
 
     def try_extract(self, html: bytes, url: str) -> SpecialCaseResult | None:
         lower = html.lower()
-        if self.markers and not any(marker in lower for marker in self.markers):
+        has_marker = any(marker in lower for marker in self.markers)
+        host = _hostname_from_url(url)
+        has_matching_host = any(_hostname_matches_domain(host, domain) for domain in self.host_domains)
+        if (self.markers or self.host_domains) and not (has_marker or has_matching_host):
             return None
         extracted = _markdown_from_first_selector(html, url, self.selectors)
         if extracted is None:
@@ -311,7 +324,7 @@ class GitBookExtractor(StaticRegionFrameworkExtractor):
 
     name = "gitbook"
     framework = "gitbook"
-    markers = (b"gitbook", b"data-testid=\"page.content\"", b"data-testid='page.content'")
+    markers = (b"gitbook", b'data-testid="page.content"', b"data-testid='page.content'")
     selectors = (
         "[data-testid='page.content']",
         '[data-testid="page.content"]',
@@ -327,7 +340,8 @@ class ReadMeExtractor(StaticRegionFrameworkExtractor):
 
     name = "readme"
     framework = "readme"
-    markers = (b"readme.io", b"rm-markdown", b"rdmd")
+    markers = (b"rm-markdown", b"rdmd")
+    host_domains = ("readme.io",)
     selectors = (
         ".rm-Markdown",
         ".rm-markdown",
@@ -769,11 +783,11 @@ class SphinxObjectsInvExtractor:
     )
 
     def try_extract(self, html: bytes, url: str) -> SpecialCaseResult | None:
-        host = urlparse(url).hostname or ""
+        host = _hostname_from_url(url)
         if (
             b'name="generator" content="sphinx' not in html.lower()
             and b"sphinx" not in html.lower()
-            and not host.endswith("readthedocs.io")
+            and not _hostname_matches_domain(host, "readthedocs.io")
         ):
             return None
         extracted = _markdown_from_first_selector(html, url, self._SELECTORS)
@@ -927,9 +941,10 @@ def detect_source_type(html: bytes, url: str) -> str:
         return "vitepress"
     if b"starlight" in lower or b"sl-markdown-content" in lower:
         return "starlight"
-    if b"gitbook" in lower or b"data-testid=\"page.content\"" in lower:
+    if b"gitbook" in lower or b'data-testid="page.content"' in lower:
         return "gitbook"
-    if b"readme.io" in lower or b"rm-markdown" in lower:
+    host = _hostname_from_url(url)
+    if _hostname_matches_domain(host, "readme.io") or b"rm-markdown" in lower:
         return "readme"
     if b"redoc" in lower or b"scalar-api-reference" in lower:
         return "api_reference"
@@ -937,8 +952,7 @@ def detect_source_type(html: bytes, url: str) -> str:
         return "docusaurus"
     if b'name="generator" content="sphinx' in lower:
         return "sphinx"
-    host = urlparse(url).hostname or ""
-    if host.endswith("readthedocs.io"):
+    if _hostname_matches_domain(host, "readthedocs.io"):
         return "sphinx"
     return "generic"
 

--- a/src/docpull/conversion/special_cases.py
+++ b/src/docpull/conversion/special_cases.py
@@ -67,6 +67,41 @@ def _soup(html: bytes) -> BeautifulSoup:
     return BeautifulSoup(_decode_html(html), "html.parser")
 
 
+def _title_from_soup(soup: BeautifulSoup) -> str | None:
+    if soup.title and soup.title.string:
+        title = soup.title.string.strip()
+        if title:
+            return title
+    heading = soup.find(["h1", "h2"])
+    if heading:
+        title = heading.get_text(" ", strip=True)
+        if title:
+            return title
+    return None
+
+
+def _markdown_from_first_selector(
+    html: bytes,
+    url: str,
+    selectors: tuple[str, ...],
+) -> tuple[str, str | None] | None:
+    """Convert the first useful static HTML region to Markdown."""
+    soup = _soup(html)
+    for selector in selectors:
+        node = soup.select_one(selector)
+        if not isinstance(node, Tag):
+            continue
+        text = node.get_text(" ", strip=True)
+        if len(text) < 80:
+            continue
+        from .markdown import HtmlToMarkdown
+
+        markdown = HtmlToMarkdown().convert(str(node), url).strip()
+        if markdown:
+            return markdown + "\n", _title_from_soup(soup)
+    return None
+
+
 def _walk_text(node: Any) -> str:
     """Recursively flatten a Next.js/MDX AST-like JSON tree to plain text."""
     if node is None:
@@ -175,22 +210,147 @@ class NextDataExtractor:
 
 
 class DocusaurusExtractor:
-    """Detect Docusaurus pages and fall through to generic extraction.
-
-    Docusaurus v2+ pages render full content into ``article`` tags at build
-    time, so the generic extractor handles them fine. This extractor exists
-    primarily to *tag* the source so downstream code knows the content is
-    Docusaurus-shaped (for chunking, etc.).
-    """
+    """Extract static Docusaurus documentation pages."""
 
     name = "docusaurus"
+
+    _SELECTORS = (
+        "article",
+        "main article",
+        ".theme-doc-markdown",
+        ".markdown",
+        "main",
+    )
 
     def try_extract(self, html: bytes, url: str) -> SpecialCaseResult | None:
         # Signature: docusaurus writes a root div id and meta generator
         if b"docusaurus" not in html.lower() and b"__docusaurus" not in html:
             return None
-        # Let the generic extractor handle it; we just flag the source.
-        return None
+        extracted = _markdown_from_first_selector(html, url, self._SELECTORS)
+        if extracted is None:
+            return None
+        markdown, title = extracted
+        return SpecialCaseResult(
+            markdown=markdown,
+            title=title,
+            source_type=self.name,
+            extra={"framework": "docusaurus"},
+        )
+
+
+class StaticRegionFrameworkExtractor:
+    """Base extractor for frameworks that ship useful static HTML regions."""
+
+    name = "static_framework"
+    framework = "static"
+    markers: tuple[bytes, ...] = ()
+    selectors: tuple[str, ...] = ("article", "main")
+
+    def try_extract(self, html: bytes, url: str) -> SpecialCaseResult | None:
+        lower = html.lower()
+        if self.markers and not any(marker in lower for marker in self.markers):
+            return None
+        extracted = _markdown_from_first_selector(html, url, self.selectors)
+        if extracted is None:
+            return None
+        markdown, title = extracted
+        return SpecialCaseResult(
+            markdown=markdown,
+            title=title,
+            source_type=self.name,
+            extra={"framework": self.framework},
+        )
+
+
+class MkDocsMaterialExtractor(StaticRegionFrameworkExtractor):
+    """Extract MkDocs / Material for MkDocs static pages."""
+
+    name = "mkdocs"
+    framework = "mkdocs"
+    markers = (b"mkdocs", b"md-content", b"material for mkdocs")
+    selectors = (
+        "article.md-content__inner",
+        ".md-content__inner",
+        ".md-content",
+        "main article",
+        "article",
+        "main",
+    )
+
+
+class VitePressExtractor(StaticRegionFrameworkExtractor):
+    """Extract VitePress / VuePress-style static docs pages."""
+
+    name = "vitepress"
+    framework = "vitepress"
+    markers = (b"vitepress", b"vp-doc", b"vpdoc")
+    selectors = (
+        ".VPDoc .content",
+        ".vp-doc",
+        "main .content",
+        "main",
+        "article",
+    )
+
+
+class StarlightExtractor(StaticRegionFrameworkExtractor):
+    """Extract Astro Starlight static docs pages."""
+
+    name = "starlight"
+    framework = "starlight"
+    markers = (b"starlight", b"sl-markdown-content", b"astro")
+    selectors = (
+        ".sl-markdown-content",
+        "article",
+        "main",
+    )
+
+
+class GitBookExtractor(StaticRegionFrameworkExtractor):
+    """Extract GitBook static documentation pages."""
+
+    name = "gitbook"
+    framework = "gitbook"
+    markers = (b"gitbook", b"data-testid=\"page.content\"", b"data-testid='page.content'")
+    selectors = (
+        "[data-testid='page.content']",
+        '[data-testid="page.content"]',
+        ".markdown",
+        "main article",
+        "article",
+        "main",
+    )
+
+
+class ReadMeExtractor(StaticRegionFrameworkExtractor):
+    """Extract ReadMe.io static documentation pages."""
+
+    name = "readme"
+    framework = "readme"
+    markers = (b"readme.io", b"rm-markdown", b"rdmd")
+    selectors = (
+        ".rm-Markdown",
+        ".rm-markdown",
+        ".markdown-body",
+        "article",
+        "main",
+    )
+
+
+class RedocScalarExtractor(StaticRegionFrameworkExtractor):
+    """Extract static Redoc or Scalar API reference pages."""
+
+    name = "api_reference"
+    framework = "redoc_scalar"
+    markers = (b"redoc", b"scalar-api-reference", b"scalar")
+    selectors = (
+        "redoc",
+        "#redoc-container",
+        ".api-content",
+        ".scalar-app",
+        "article",
+        "main",
+    )
 
 
 class MintlifyExtractor:
@@ -595,19 +755,37 @@ class RawTextExtractor:
 
 
 class SphinxObjectsInvExtractor:
-    """Detect Sphinx-built docs and let the generic extractor run.
-
-    Sphinx emits predictable ``div.body`` / ``div.document`` wrappers that
-    ``MainContentExtractor`` already captures. We only tag the source so
-    downstream code knows the content is Sphinx-flavored.
-    """
+    """Extract static Sphinx-built documentation pages."""
 
     name = "sphinx"
 
+    _SELECTORS = (
+        "div.body",
+        "main div.body",
+        "div.document",
+        "[role='main']",
+        "main",
+        "article",
+    )
+
     def try_extract(self, html: bytes, url: str) -> SpecialCaseResult | None:
-        if b'name="generator" content="Sphinx' not in html and b"sphinx" not in html.lower():
+        host = urlparse(url).hostname or ""
+        if (
+            b'name="generator" content="sphinx' not in html.lower()
+            and b"sphinx" not in html.lower()
+            and not host.endswith("readthedocs.io")
+        ):
             return None
-        return None
+        extracted = _markdown_from_first_selector(html, url, self._SELECTORS)
+        if extracted is None:
+            return None
+        markdown, title = extracted
+        return SpecialCaseResult(
+            markdown=markdown,
+            title=title,
+            source_type=self.name,
+            extra={"framework": "sphinx"},
+        )
 
 
 class MdxSourceExtractor:
@@ -652,6 +830,12 @@ DEFAULT_CHAIN: list[SpecialCaseExtractor] = [
     RawTextExtractor(),
     MintlifyExtractor(),
     NextDataExtractor(),
+    MkDocsMaterialExtractor(),
+    VitePressExtractor(),
+    StarlightExtractor(),
+    GitBookExtractor(),
+    ReadMeExtractor(),
+    RedocScalarExtractor(),
     DocusaurusExtractor(),
     SphinxObjectsInvExtractor(),
 ]
@@ -737,6 +921,18 @@ def detect_source_type(html: bytes, url: str) -> str:
     for marker in _NEXTJS_APP_ROUTER_MARKERS:
         if marker in lower:
             return "nextjs"
+    if b"mkdocs" in lower or b"md-content" in lower:
+        return "mkdocs"
+    if b"vitepress" in lower or b"vp-doc" in lower:
+        return "vitepress"
+    if b"starlight" in lower or b"sl-markdown-content" in lower:
+        return "starlight"
+    if b"gitbook" in lower or b"data-testid=\"page.content\"" in lower:
+        return "gitbook"
+    if b"readme.io" in lower or b"rm-markdown" in lower:
+        return "readme"
+    if b"redoc" in lower or b"scalar-api-reference" in lower:
+        return "api_reference"
     if b"docusaurus" in lower:
         return "docusaurus"
     if b'name="generator" content="sphinx' in lower:
@@ -750,14 +946,20 @@ def detect_source_type(html: bytes, url: str) -> str:
 __all__ = [
     "DEFAULT_CHAIN",
     "DocusaurusExtractor",
+    "GitBookExtractor",
+    "MkDocsMaterialExtractor",
     "MdxSourceExtractor",
     "MintlifyExtractor",
     "NextDataExtractor",
     "OpenApiExtractor",
     "RawTextExtractor",
+    "ReadMeExtractor",
+    "RedocScalarExtractor",
     "SpecialCaseExtractor",
     "SpecialCaseResult",
     "SphinxObjectsInvExtractor",
+    "StarlightExtractor",
+    "VitePressExtractor",
     "detect_source_type",
     "find_mdx_source_url",
     "looks_like_spa",

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -597,10 +597,7 @@ class Fetcher:
 
         steps = self._pipeline.steps
         if not save:
-            steps = [
-                s.without_existing_check() if isinstance(s, ValidateStep) else s
-                for s in steps
-            ]
+            steps = [s.without_existing_check() if isinstance(s, ValidateStep) else s for s in steps]
             steps = [
                 s
                 for s in steps

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -28,6 +28,7 @@ from ..pipeline.steps import (
     JsonSaveStep,
     MetadataStep,
     NdjsonSaveStep,
+    OkfSaveStep,
     SaveStep,
     SqliteSaveStep,
     ValidateStep,
@@ -137,6 +138,47 @@ def _url_to_path_parts(url: str, base_url: str | None = None) -> list[str]:
     return [*sanitized[:-1], last + ".md"]
 
 
+def _url_to_okf_path_parts(url: str, base_url: str | None = None) -> list[str]:
+    """
+    Convert URL to OKF-safe concept path segments.
+
+    OKF reserves ``index.md`` for generated directory listings and ``log.md``
+    for update history, so scraped pages never use those filenames.
+    """
+    parsed = urlparse(url)
+    raw_path = parsed.path
+
+    if base_url:
+        base_path = urlparse(base_url).path.strip("/")
+        stripped = raw_path.strip("/")
+        if base_path and stripped.startswith(base_path):
+            stripped = stripped[len(base_path) :]
+            raw_path = "/" + stripped + ("/" if raw_path.endswith("/") else "")
+
+    trailing_slash = raw_path.endswith("/")
+    parts = [seg for seg in raw_path.split("/") if seg]
+
+    if not parts:
+        return ["_root.md"]
+
+    sanitized = [_sanitize_path_segment(p) for p in parts]
+    last = sanitized[-1]
+    if last.endswith(".html") or last.endswith(".htm"):
+        last = last.rsplit(".", 1)[0]
+
+    if trailing_slash:
+        return [*sanitized, "_page.md"]
+
+    if last == "index":
+        leaf = "_root.md" if len(sanitized) == 1 else "_page.md"
+        return [*sanitized[:-1], leaf]
+
+    if last == "log":
+        return [*sanitized[:-1], "_log.md"]
+
+    return [*sanitized[:-1], last + ".md"]
+
+
 class Fetcher:
     """
     Primary API for docpull v2.0 - streaming events.
@@ -189,7 +231,9 @@ class Fetcher:
         self._json_saver: JsonSaveStep | None = None
         self._sqlite_saver: SqliteSaveStep | None = None
         self._ndjson_saver: NdjsonSaveStep | None = None
+        self._okf_saver: OkfSaveStep | None = None
         self._save_step: SaveStep | None = None
+        self._output_was_used = False
 
     def _run_fingerprint(self) -> dict[str, object]:
         return self.run_identity.fingerprint()
@@ -317,7 +361,6 @@ class Fetcher:
         self._apply_robots_crawl_delay()
 
         output_dir = self.config.output.directory.resolve()
-        output_dir.mkdir(parents=True, exist_ok=True)
 
         if self.config.cache.enabled:
             cache_dir = self.config.cache.directory.resolve()
@@ -389,6 +432,13 @@ class Fetcher:
         elif self.config.output.format == "sqlite":
             self._sqlite_saver = SqliteSaveStep(base_output_dir=output_dir, run_identity=self.run_identity)
             steps.append(self._sqlite_saver)
+        elif self.config.output.format == "okf":
+            self._okf_saver = OkfSaveStep(
+                base_output_dir=output_dir,
+                emit_chunks=self.config.output.emit_chunks,
+                run_identity=self.run_identity,
+            )
+            steps.append(self._okf_saver)
         else:
             # Default to markdown file output. SaveStep also writes
             # SKILL.md on finalize() when output.skill_name is set.
@@ -463,23 +513,29 @@ class Fetcher:
             await self._http_client.__aexit__(exc_type, exc_val, exc_tb)
             self._http_client = None
 
-        # Finalize JSON/NDJSON/SQLite savers
-        if self._json_saver:
-            self._json_saver.finalize()
-            self._json_saver = None
+        if self._output_was_used:
+            # Finalize JSON/NDJSON/SQLite savers
+            if self._json_saver:
+                self._json_saver.finalize()
 
-        if self._ndjson_saver:
-            self._ndjson_saver.finalize()
-            self._ndjson_saver = None
+            if self._ndjson_saver:
+                self._ndjson_saver.finalize()
 
-        if self._sqlite_saver:
-            self._sqlite_saver.close()
-            self._sqlite_saver = None
+            if self._sqlite_saver:
+                self._sqlite_saver.close()
 
-        # Write SKILL.md when --skill mode produced a manifest-shaped run.
-        if self._save_step:
-            self._save_step.finalize()
-            self._save_step = None
+            if self._okf_saver:
+                self._okf_saver.finalize()
+
+            # Write SKILL.md when --skill mode produced a manifest-shaped run.
+            if self._save_step:
+                self._save_step.finalize()
+
+        self._json_saver = None
+        self._ndjson_saver = None
+        self._sqlite_saver = None
+        self._okf_saver = None
+        self._save_step = None
 
         # Flush cache to disk
         if self._cache_manager:
@@ -535,11 +591,21 @@ class Fetcher:
         """
         if self._pipeline is None:
             raise RuntimeError("Fetcher not initialized. Use 'async with' context manager.")
+        if save:
+            self._output_was_used = True
         output_path = self._compute_output_path(url)
 
         steps = self._pipeline.steps
         if not save:
-            steps = [s for s in steps if s.name not in {"save", "save_json", "save_ndjson", "save_sqlite"}]
+            steps = [
+                s.without_existing_check() if isinstance(s, ValidateStep) else s
+                for s in steps
+            ]
+            steps = [
+                s
+                for s in steps
+                if s.name not in {"save", "save_json", "save_ndjson", "save_sqlite", "save_okf"}
+            ]
         pipeline = type(self._pipeline)(steps=steps)
         ctx = await pipeline.execute(url, output_path)
         if ctx.error:
@@ -566,6 +632,10 @@ class Fetcher:
         """
         output_dir = self.config.output.directory.resolve()
         strategy = self.config.output.naming_strategy
+
+        if self.config.output.format == "okf":
+            parts = _url_to_okf_path_parts(url, self.config.url)
+            return output_dir.joinpath(*parts)
 
         if strategy == "hierarchical":
             parts = _url_to_path_parts(url, self.config.url)
@@ -602,6 +672,7 @@ class Fetcher:
         if self._pipeline is None or self._discoverer is None:
             raise RuntimeError("Fetcher not initialized. Use 'async with' context manager.")
 
+        self._output_was_used = True
         self._start_time = time.monotonic()
         yield FetchEvent(
             type=EventType.STARTED,

--- a/src/docpull/models/config.py
+++ b/src/docpull/models/config.py
@@ -17,6 +17,7 @@ class ProfileName(str, Enum):
     MIRROR = "mirror"
     QUICK = "quick"
     LLM = "llm"
+    OKF = "okf"
     CUSTOM = "custom"
 
 
@@ -138,7 +139,7 @@ class OutputConfig(BaseModel):
     """Configuration for output formatting and file saving."""
 
     directory: Path = Field(Path("./docs"), description="Output directory for fetched content")
-    format: Literal["markdown", "json", "ndjson", "sqlite"] = Field(
+    format: Literal["markdown", "json", "ndjson", "sqlite", "okf"] = Field(
         "markdown",
         description="Output format",
     )

--- a/src/docpull/models/profiles.py
+++ b/src/docpull/models/profiles.py
@@ -61,6 +61,18 @@ PROFILES: dict[ProfileName, dict[str, Any]] = {
             "emit_chunks": True,
         },
     },
+    ProfileName.OKF: {
+        # Open Knowledge Format bundle: Markdown concepts with OKF frontmatter
+        # plus generated index.md files for progressive disclosure.
+        "content_filter": {
+            "streaming_dedup": True,
+        },
+        "output": {
+            "format": "okf",
+            "rich_metadata": True,
+            "naming_strategy": "hierarchical",
+        },
+    },
     ProfileName.CUSTOM: {
         # No overrides - use explicit config
     },

--- a/src/docpull/pipeline/manifest.py
+++ b/src/docpull/pipeline/manifest.py
@@ -29,7 +29,7 @@ class CorpusManifest:
         self._records: list[dict[str, Any]] = []
         self._seen: set[str] = set()
 
-    def add_record(self, record: DocumentRecord, output_path: Path | None = None) -> None:
+    def add_record(self, record: DocumentRecord, output_path: Path | str | None = None) -> None:
         record_key = record.chunk_id or record.document_id
         if record_key in self._seen:
             return
@@ -51,7 +51,9 @@ class CorpusManifest:
             item["chunk_heading"] = record.chunk_heading
         if record.token_count is not None:
             item["token_count"] = record.token_count
-        if output_path is not None:
+        if isinstance(output_path, str):
+            item["output_path"] = output_path
+        elif output_path is not None:
             try:
                 item["output_path"] = str(output_path.resolve().relative_to(self._base_dir))
             except ValueError:

--- a/src/docpull/pipeline/steps/__init__.py
+++ b/src/docpull/pipeline/steps/__init__.py
@@ -8,7 +8,8 @@ from .metadata import MetadataStep
 from .save import SaveStep
 from .save_json import JsonSaveStep
 from .save_ndjson import NdjsonSaveStep
-from .save_sqlite import SqliteSaveStep
+from .save_okf import OkfSaveStep
+from .save_sqlite import SqliteSaveStep, SqliteSearchResult, search_sqlite_documents
 from .validate import ValidateStep
 
 __all__ = [
@@ -19,7 +20,10 @@ __all__ = [
     "JsonSaveStep",
     "MetadataStep",
     "NdjsonSaveStep",
+    "OkfSaveStep",
     "SaveStep",
     "SqliteSaveStep",
+    "SqliteSearchResult",
     "ValidateStep",
+    "search_sqlite_documents",
 ]

--- a/src/docpull/pipeline/steps/save_ndjson.py
+++ b/src/docpull/pipeline/steps/save_ndjson.py
@@ -94,6 +94,10 @@ class NdjsonSaveStep:
             return ctx
 
         async with self._lock:
+            self._ensure_open()
+            manifest_output_path: Path | str | None = (
+                self._output_path if self._output_path is not None else "-"
+            )
             if self._emit_chunks and ctx.chunks:
                 for chunk in ctx.chunks:
                     text = getattr(chunk, "text", "")
@@ -109,7 +113,7 @@ class NdjsonSaveStep:
                         chunk_heading=getattr(chunk, "heading", None),
                         token_count=getattr(chunk, "token_count", None),
                     )
-                    self._manifest.add_record(record, self._output_path)
+                    self._manifest.add_record(record, manifest_output_path)
                     self._add_source_index_record(record)
                     self._write_record(record.model_dump(mode="json", exclude_none=True))
                     self._chunk_count += 1
@@ -123,7 +127,7 @@ class NdjsonSaveStep:
                     source_type=ctx.source_type,
                     run_identity=self._run_identity,
                 )
-                self._manifest.add_record(record, self._output_path)
+                self._manifest.add_record(record, manifest_output_path)
                 self._add_source_index_record(record)
                 self._write_record(record.model_dump(mode="json", exclude_none=True))
             self._document_count += 1

--- a/src/docpull/pipeline/steps/save_okf.py
+++ b/src/docpull/pipeline/steps/save_okf.py
@@ -1,0 +1,372 @@
+"""Open Knowledge Format save step."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from ...conversion.markdown import FrontmatterBuilder
+from ...conversion.special_cases import _split_markdown_frontmatter
+from ...models.document import DocumentRecord
+from ...models.events import EventType, FetchEvent, SkipReason
+from ...models.run import RunIdentity
+from ..base import EventEmitter, PageContext
+from ..manifest import CorpusManifest
+from .convert import _extract_headings
+
+logger = logging.getLogger(__name__)
+
+OKF_CONCEPT_TYPE = "Documentation Page"
+OKF_CHUNK_TYPE = "Documentation Chunk"
+_INDEX_FILENAME = "index.md"
+
+
+@dataclass(frozen=True)
+class OkfIndexEntry:
+    """One generated OKF concept entry for directory indexes."""
+
+    relative_path: str
+    title: str
+    description: str | None = None
+
+
+class OkfSaveStep:
+    """Save converted Markdown as an OKF bundle."""
+
+    name = "save_okf"
+
+    def __init__(
+        self,
+        base_output_dir: Path,
+        *,
+        emit_chunks: bool = False,
+        run_identity: RunIdentity | None = None,
+    ) -> None:
+        self._base_output_dir = base_output_dir
+        self._emit_chunks = emit_chunks
+        self._run_identity = run_identity
+        self._frontmatter_builder = FrontmatterBuilder()
+        self._manifest = CorpusManifest(
+            base_output_dir,
+            output_format="okf",
+            run_identity=run_identity,
+        )
+        self._index_entries: list[OkfIndexEntry] = []
+        self._seen_entries: set[str] = set()
+
+    def _validate_output_path(self, output_path: Path) -> Path:
+        resolved = output_path.resolve()
+        base_resolved = self._base_output_dir.resolve()
+        try:
+            resolved.relative_to(base_resolved)
+        except ValueError as err:
+            raise ValueError(f"Output path {resolved} is outside base directory {base_resolved}") from err
+        return resolved
+
+    async def execute(
+        self,
+        ctx: PageContext,
+        emit: EventEmitter | None = None,
+    ) -> PageContext:
+        if ctx.markdown is not None:
+            body = ctx.markdown
+        elif ctx.html is not None:
+            body = ctx.html.decode("utf-8", errors="replace")
+        else:
+            ctx.mark_skipped("No content to save", SkipReason.NO_CONTENT_TO_SAVE)
+            logger.warning("Skipping %s: no content to save", ctx.url)
+            if emit:
+                emit(
+                    FetchEvent(
+                        type=EventType.FETCH_SKIPPED,
+                        url=ctx.url,
+                        message="No content to save",
+                        skip_reason=SkipReason.NO_CONTENT_TO_SAVE,
+                    )
+                )
+            return ctx
+
+        try:
+            validated_path = self._validate_output_path(ctx.output_path)
+            validated_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if self._emit_chunks and ctx.chunks:
+                await self._write_chunks(ctx, validated_path)
+            else:
+                content = self._render_concept(ctx, body)
+                await asyncio.to_thread(validated_path.write_text, content, encoding="utf-8")
+                ctx.markdown = content
+                ctx.persisted_path = validated_path
+                record = DocumentRecord.from_page(
+                    url=ctx.url,
+                    title=ctx.title,
+                    content=content,
+                    metadata=ctx.metadata,
+                    extraction=ctx.extraction_info,
+                    source_type=ctx.source_type,
+                    run_identity=self._run_identity,
+                )
+                self._manifest.add_record(record, validated_path)
+                self._add_index_entry(validated_path, self._entry_title(ctx), self._description(ctx.metadata))
+                logger.info("Saved OKF concept: %s", validated_path)
+
+            if emit:
+                emit(
+                    FetchEvent(
+                        type=EventType.PAGE_SAVED,
+                        url=ctx.url,
+                        output_path=validated_path,
+                        message=f"Saved OKF concept to {validated_path}",
+                    )
+                )
+            return ctx
+
+        except ValueError as e:
+            ctx.mark_failed(str(e))
+            logger.error("Path validation failed for %s: %s", ctx.url, e)
+            if emit:
+                emit(
+                    FetchEvent(
+                        type=EventType.FETCH_FAILED,
+                        url=ctx.url,
+                        error=str(e),
+                        output_path=ctx.output_path,
+                        message=f"Path validation failed: {e}",
+                    )
+                )
+            raise
+        except OSError as e:
+            ctx.mark_failed(f"Failed to save OKF concept: {e}")
+            logger.error("Failed to save %s to %s: %s", ctx.url, ctx.output_path, e)
+            if emit:
+                emit(
+                    FetchEvent(
+                        type=EventType.FETCH_FAILED,
+                        url=ctx.url,
+                        output_path=ctx.output_path,
+                        error=str(e),
+                        message=f"Failed to save OKF concept: {e}",
+                    )
+                )
+            raise
+
+    async def _write_chunks(
+        self,
+        ctx: PageContext,
+        validated_path: Path,
+    ) -> None:
+        stem = validated_path.stem
+        parent = validated_path.parent
+        ext = validated_path.suffix or ".md"
+        width = max(2, len(str(len(ctx.chunks) - 1)))
+        first_chunk_path: Path | None = None
+        for chunk in ctx.chunks:
+            idx = getattr(chunk, "index", 0)
+            text = getattr(chunk, "text", "")
+            heading = getattr(chunk, "heading", None)
+            title = self._entry_title(ctx, suffix=f"chunk {idx + 1}")
+            content = self._render_concept(
+                ctx,
+                text,
+                concept_type=OKF_CHUNK_TYPE,
+                chunk_index=idx,
+                chunk_heading=heading,
+                token_count=getattr(chunk, "token_count", None),
+            )
+            chunk_path = parent / f"{stem}.{idx:0{width}d}{ext}"
+            await asyncio.to_thread(chunk_path.write_text, content, encoding="utf-8")
+            record = DocumentRecord.from_page(
+                url=ctx.url,
+                title=ctx.title,
+                content=content,
+                metadata=ctx.metadata,
+                extraction=ctx.extraction_info,
+                source_type=ctx.source_type,
+                run_identity=self._run_identity,
+                chunk_index=idx,
+                chunk_heading=heading,
+                token_count=getattr(chunk, "token_count", None),
+            )
+            self._manifest.add_record(record, chunk_path)
+            self._add_index_entry(chunk_path, title, heading or self._description(ctx.metadata))
+            if first_chunk_path is None:
+                first_chunk_path = chunk_path
+        ctx.persisted_path = first_chunk_path
+        logger.info("Saved %d OKF chunks: %s.*%s", len(ctx.chunks), parent / stem, ext)
+
+    def _render_concept(
+        self,
+        ctx: PageContext,
+        body: str,
+        *,
+        concept_type: str = OKF_CONCEPT_TYPE,
+        chunk_index: int | None = None,
+        chunk_heading: str | None = None,
+        token_count: int | None = None,
+    ) -> str:
+        _, stripped_body = _split_markdown_frontmatter(body)
+        stripped_body = stripped_body.strip()
+        metadata = ctx.metadata or {}
+        extra = self._extra_fields(ctx, stripped_body)
+        if chunk_index is not None:
+            extra["chunk_index"] = chunk_index
+        if chunk_heading:
+            extra["chunk_heading"] = chunk_heading
+        if token_count is not None:
+            extra["token_count"] = token_count
+        frontmatter = self._frontmatter_builder.build_okf(
+            concept_type=concept_type,
+            title=ctx.title,
+            resource=ctx.url,
+            description=self._description(metadata),
+            tags=self._tags(metadata),
+            timestamp=self._timestamp(metadata),
+            source=ctx.url,
+            **extra,
+        )
+        return frontmatter + stripped_body + "\n"
+
+    def _extra_fields(self, ctx: PageContext, body: str) -> dict[str, Any]:
+        metadata = ctx.metadata or {}
+        extra: dict[str, Any] = {}
+        if ctx.source_type and ctx.source_type != "generic":
+            extra["source_type"] = ctx.source_type
+        for key in ("author", "section", "canonical_url", "site_name", "framework"):
+            value = metadata.get(key)
+            if value:
+                extra[key] = value
+        headings = _extract_headings(body)
+        if headings:
+            extra["headings"] = headings
+        return extra
+
+    @staticmethod
+    def _description(metadata: dict[str, Any]) -> str | None:
+        value = metadata.get("description")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    @staticmethod
+    def _timestamp(metadata: dict[str, Any]) -> str | None:
+        for key in ("modified_time", "published_time"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _tags(metadata: dict[str, Any]) -> list[str] | None:
+        raw = metadata.get("tags") or metadata.get("keywords")
+        values: list[str]
+        if isinstance(raw, str):
+            values = [part.strip() for part in raw.split(",")]
+        elif isinstance(raw, (list, tuple, set)):
+            values = [str(part).strip() for part in raw]
+        else:
+            return None
+        seen: set[str] = set()
+        tags: list[str] = []
+        for value in values:
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            tags.append(value)
+        return tags or None
+
+    def _entry_title(self, ctx: PageContext, suffix: str | None = None) -> str:
+        title = ctx.title or Path(ctx.output_path).stem.replace("_", " ").strip() or "Untitled"
+        return f"{title} ({suffix})" if suffix else title
+
+    @staticmethod
+    def _index_text(value: str | None) -> str:
+        if not value:
+            return ""
+        return str(value).replace("\r", " ").replace("\n", " ").replace("\x00", " ").strip()
+
+    @classmethod
+    def _link_label(cls, value: str) -> str:
+        return cls._index_text(value).replace("[", r"\[").replace("]", r"\]")
+
+    def _add_index_entry(self, output_path: Path, title: str, description: str | None) -> None:
+        relative_path = output_path.resolve().relative_to(self._base_output_dir.resolve()).as_posix()
+        if relative_path in self._seen_entries:
+            return
+        self._seen_entries.add(relative_path)
+        self._index_entries.append(
+            OkfIndexEntry(
+                relative_path=relative_path,
+                title=title,
+                description=description,
+            )
+        )
+
+    def finalize(self) -> Path:
+        """Write the corpus manifest and generated OKF index files."""
+        manifest_path = self._manifest.finalize()
+        self._write_indexes()
+        return manifest_path
+
+    def _write_indexes(self) -> None:
+        if not self._index_entries:
+            return
+
+        dirs: set[PurePosixPath] = {PurePosixPath(".")}
+        for entry in self._index_entries:
+            parent = PurePosixPath(entry.relative_path).parent
+            dirs.add(parent)
+            while str(parent) not in {"", "."}:
+                parent = parent.parent
+                dirs.add(parent)
+
+        for directory in sorted(dirs, key=lambda item: item.as_posix()):
+            content = self._render_index(directory)
+            if str(directory) == ".":
+                content = '---\nokf_version: "0.1"\n---\n\n' + content
+            relative_dir = Path() if str(directory) == "." else Path(directory.as_posix())
+            index_path = self._base_output_dir / relative_dir
+            index_path.mkdir(parents=True, exist_ok=True)
+            (index_path / _INDEX_FILENAME).write_text(content, encoding="utf-8")
+
+    def _render_index(self, directory: PurePosixPath) -> str:
+        direct_entries: list[OkfIndexEntry] = []
+        subdirs: dict[str, int] = {}
+        for entry in self._index_entries:
+            path = PurePosixPath(entry.relative_path)
+            parent = path.parent
+            if parent == directory:
+                direct_entries.append(entry)
+                continue
+            try:
+                relative = path.relative_to(directory)
+            except ValueError:
+                continue
+            parts = relative.parts
+            if len(parts) > 1:
+                subdirs[parts[0]] = subdirs.get(parts[0], 0) + 1
+
+        lines: list[str] = []
+        if direct_entries:
+            lines.extend(["# Concepts", ""])
+            for entry in sorted(direct_entries, key=lambda item: item.title.lower()):
+                filename = PurePosixPath(entry.relative_path).name
+                label = self._link_label(entry.title)
+                description_text = self._index_text(entry.description)
+                description = f" - {description_text}" if description_text else ""
+                lines.append(f"* [{label}]({filename}){description}")
+            lines.append("")
+
+        if subdirs:
+            lines.extend(["# Directories", ""])
+            for name, count in sorted(subdirs.items()):
+                label = self._link_label(name.replace("_", " "))
+                noun = "concept" if count == 1 else "concepts"
+                lines.append(f"* [{label}]({name}/) - {count} {noun}")
+            lines.append("")
+
+        if not lines:
+            lines = ["# Concepts", ""]
+        return "\n".join(lines).rstrip() + "\n"

--- a/src/docpull/pipeline/steps/save_sqlite.py
+++ b/src/docpull/pipeline/steps/save_sqlite.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 from ...models.document import DocumentRecord
@@ -14,6 +15,16 @@ from ..base import EventEmitter, PageContext
 from ..manifest import CorpusManifest
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SqliteSearchResult:
+    """One full-text search hit from a docpull SQLite output database."""
+
+    url: str
+    title: str | None
+    snippet: str
+    rank: float
 
 
 class SqliteSaveStep:
@@ -100,6 +111,7 @@ class SqliteSaveStep:
                     "extraction": "TEXT",
                 },
             )
+            self._ensure_fts(self._conn)
             if self._run_identity:
                 self._conn.execute(
                     "INSERT OR REPLACE INTO run_metadata (key, value) VALUES (?, ?)",
@@ -119,6 +131,27 @@ class SqliteSaveStep:
         for name, definition in columns.items():
             if name not in existing:
                 conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
+
+    @staticmethod
+    def _ensure_fts(conn: sqlite3.Connection) -> None:
+        """Create and backfill the local full-text search index."""
+        conn.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+                url UNINDEXED,
+                title,
+                content,
+                content_hash UNINDEXED
+            )
+        """)
+        conn.execute("""
+            INSERT INTO documents_fts (url, title, content, content_hash)
+            SELECT d.url, d.title, d.content, d.content_hash
+            FROM documents d
+            WHERE d.content IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM documents_fts f WHERE f.url = d.url
+              )
+        """)
 
     async def execute(
         self,
@@ -172,6 +205,13 @@ class SqliteSaveStep:
                 self._document_count += 1
                 self._pending_count += 1
                 self._manifest.add_record(record, self._db_path)
+                conn.execute(
+                    """
+                    INSERT INTO documents_fts (url, title, content, content_hash)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (record.url, record.title, record.content, record.content_hash),
+                )
 
             # Batch commits for performance
             if self._pending_count >= self.BATCH_SIZE:
@@ -225,3 +265,54 @@ class SqliteSaveStep:
     def db_path(self) -> Path:
         """Return the path to the database file."""
         return self._db_path
+
+
+def search_sqlite_documents(
+    db_path: Path,
+    query: str,
+    *,
+    limit: int = 10,
+) -> list[SqliteSearchResult]:
+    """Search a docpull SQLite output database with FTS5.
+
+    Args:
+        db_path: Path to ``documents.db``.
+        query: FTS5 query string.
+        limit: Maximum number of hits to return.
+
+    Returns:
+        Search hits ordered by FTS rank.
+    """
+    if not query.strip():
+        return []
+    if limit < 1:
+        return []
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                url,
+                title,
+                snippet(documents_fts, 2, '[', ']', ' ... ', 24) AS snippet,
+                bm25(documents_fts) AS rank
+            FROM documents_fts
+            WHERE documents_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (query, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        SqliteSearchResult(
+            url=str(row[0]),
+            title=str(row[1]) if row[1] is not None else None,
+            snippet=str(row[2] or ""),
+            rank=float(row[3] or 0.0),
+        )
+        for row in rows
+    ]

--- a/src/docpull/pipeline/steps/validate.py
+++ b/src/docpull/pipeline/steps/validate.py
@@ -1,5 +1,7 @@
 """ValidateStep - URL validation pipeline step."""
 
+from __future__ import annotations
+
 import logging
 
 from ...models.events import EventType, FetchEvent, SkipReason
@@ -55,6 +57,14 @@ class ValidateStep:
         self._url_validator = url_validator
         self._robots_checker = robots_checker
         self._check_existing = check_existing and not cache_enabled
+
+    def without_existing_check(self) -> ValidateStep:
+        """Return an equivalent validator that ignores existing output files."""
+        return ValidateStep(
+            url_validator=self._url_validator,
+            robots_checker=self._robots_checker,
+            check_existing=False,
+        )
 
     async def execute(
         self,

--- a/src/docpull/scraper.py
+++ b/src/docpull/scraper.py
@@ -1,0 +1,351 @@
+"""Scraper-facing API built on top of the core Fetcher.
+
+This module intentionally does not introduce a second crawling engine. It gives
+users scraper-native names for docpull's existing browser-free, SSRF-hardened
+fetch/convert pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from .core.fetcher import Fetcher
+from .models.config import (
+    DocpullConfig,
+    ProfileName,
+)
+from .models.events import FetchEvent, FetchStats
+from .pipeline.base import PageContext
+
+ExtractorName = Literal["default", "trafilatura"]
+OutputFormat = Literal["markdown", "json", "ndjson", "sqlite", "okf"]
+
+
+@dataclass(frozen=True)
+class ScrapeResult:
+    """In-memory result for a single scraped URL."""
+
+    url: str
+    markdown: str
+    title: str | None = None
+    source_type: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    extraction: dict[str, Any] = field(default_factory=dict)
+    chunks: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+    skipped: bool = False
+    skip_reason: str | None = None
+
+    @property
+    def text(self) -> str:
+        """Alias for callers that expect scraper results to expose text."""
+        return self.markdown
+
+    @classmethod
+    def from_context(cls, ctx: PageContext) -> ScrapeResult:
+        chunks: list[dict[str, Any]] = []
+        for chunk in ctx.chunks:
+            chunks.append(
+                {
+                    "index": getattr(chunk, "index", 0),
+                    "heading": getattr(chunk, "heading", None),
+                    "token_count": getattr(chunk, "token_count", None),
+                    "text": getattr(chunk, "text", ""),
+                }
+            )
+        return cls(
+            url=ctx.url,
+            markdown=ctx.markdown or "",
+            title=ctx.title,
+            source_type=ctx.source_type,
+            metadata=dict(ctx.metadata or {}),
+            extraction=dict(ctx.extraction_info or {}),
+            chunks=chunks,
+            error=ctx.error,
+            skipped=ctx.should_skip,
+            skip_reason=ctx.skip_reason,
+        )
+
+
+@dataclass(frozen=True)
+class ScrapeRunResult:
+    """Summary for a site scrape that writes output artifacts to disk."""
+
+    start_url: str
+    output_dir: Path
+    output_format: str
+    stats: FetchStats
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.output_dir / "corpus.manifest.json"
+
+
+class Scraper:
+    """Browser-free web scraper facade over :class:`docpull.Fetcher`."""
+
+    def __init__(
+        self,
+        *,
+        extractor: ExtractorName | None = None,
+        strict_js_required: bool | None = None,
+        **config_defaults: Any,
+    ) -> None:
+        self._extractor = extractor
+        self._strict_js_required = strict_js_required
+        self._config_defaults = dict(config_defaults)
+
+    async def scrape_one(
+        self,
+        url: str,
+        *,
+        max_tokens_per_file: int | None = None,
+        **config_kwargs: Any,
+    ) -> ScrapeResult:
+        """Fetch and convert one URL without crawling or writing files."""
+        merged_kwargs = _merge_config_kwargs(self._config_defaults, config_kwargs)
+        return await scrape_one(
+            url,
+            extractor=self._extractor,
+            strict_js_required=self._strict_js_required,
+            max_tokens_per_file=max_tokens_per_file,
+            **merged_kwargs,
+        )
+
+    async def scrape_site(
+        self,
+        url: str,
+        *,
+        output_dir: Path = Path("./docs"),
+        output_format: OutputFormat | None = None,
+        profile: ProfileName = ProfileName.RAG,
+        max_pages: int | None = None,
+        max_depth: int | None = None,
+        **config_kwargs: Any,
+    ) -> ScrapeRunResult:
+        """Crawl a site and write artifacts using docpull's output sinks."""
+        merged_kwargs = _merge_config_kwargs(self._config_defaults, config_kwargs)
+        return await scrape_site(
+            url,
+            output_dir=output_dir,
+            output_format=output_format,
+            profile=profile,
+            max_pages=max_pages,
+            max_depth=max_depth,
+            extractor=self._extractor,
+            strict_js_required=self._strict_js_required,
+            **merged_kwargs,
+        )
+
+    async def iter_scrape(
+        self,
+        url: str,
+        *,
+        output_dir: Path = Path("./docs"),
+        output_format: OutputFormat | None = None,
+        profile: ProfileName = ProfileName.RAG,
+        max_pages: int | None = None,
+        max_depth: int | None = None,
+        **config_kwargs: Any,
+    ) -> AsyncIterator[FetchEvent]:
+        """Yield streaming events for a crawl."""
+        merged_kwargs = _merge_config_kwargs(self._config_defaults, config_kwargs)
+        config = _site_config(
+            url,
+            output_dir=output_dir,
+            output_format=output_format,
+            profile=profile,
+            max_pages=max_pages,
+            max_depth=max_depth,
+            extractor=self._extractor,
+            strict_js_required=self._strict_js_required,
+            config_kwargs=merged_kwargs,
+        )
+        async with Fetcher(config) as fetcher:
+            async for event in fetcher.run():
+                yield event
+
+
+async def scrape_one(
+    url: str,
+    *,
+    extractor: ExtractorName | None = None,
+    strict_js_required: bool | None = None,
+    max_tokens_per_file: int | None = None,
+    **config_kwargs: Any,
+) -> ScrapeResult:
+    """Fetch one server-rendered/static URL and return Markdown in memory."""
+    output_data = _section_dict(config_kwargs.pop("output", None))
+    if max_tokens_per_file is not None:
+        output_data["max_tokens_per_file"] = max_tokens_per_file
+    content_filter_data = _section_dict(config_kwargs.pop("content_filter", None))
+    if extractor is not None:
+        content_filter_data["extractor"] = extractor
+    if strict_js_required is not None:
+        content_filter_data["strict_js_required"] = strict_js_required
+    config_kwargs.pop("url", None)
+    profile = config_kwargs.pop("profile", ProfileName.CUSTOM)
+    if output_data:
+        config_kwargs["output"] = output_data
+    if content_filter_data:
+        config_kwargs["content_filter"] = content_filter_data
+    config = DocpullConfig(
+        url=url,
+        profile=profile,
+        **config_kwargs,
+    )
+    async with Fetcher(config) as fetcher:
+        ctx = await fetcher.fetch_one(url, save=False)
+    return ScrapeResult.from_context(ctx)
+
+
+def scrape_one_blocking(
+    url: str,
+    *,
+    extractor: ExtractorName | None = None,
+    strict_js_required: bool | None = None,
+    max_tokens_per_file: int | None = None,
+    **config_kwargs: Any,
+) -> ScrapeResult:
+    """Synchronous wrapper for :func:`scrape_one`."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            scrape_one(
+                url,
+                extractor=extractor,
+                strict_js_required=strict_js_required,
+                max_tokens_per_file=max_tokens_per_file,
+                **config_kwargs,
+            )
+        )
+    raise RuntimeError("scrape_one_blocking() called from async context. Use scrape_one() instead.")
+
+
+async def scrape_site(
+    url: str,
+    *,
+    output_dir: Path = Path("./docs"),
+    output_format: OutputFormat | None = None,
+    profile: ProfileName = ProfileName.RAG,
+    max_pages: int | None = None,
+    max_depth: int | None = None,
+    extractor: ExtractorName | None = None,
+    strict_js_required: bool | None = None,
+    **config_kwargs: Any,
+) -> ScrapeRunResult:
+    """Crawl a server-rendered/static site and write output artifacts."""
+    config = _site_config(
+        url,
+        output_dir=output_dir,
+        output_format=output_format,
+        profile=profile,
+        max_pages=max_pages,
+        max_depth=max_depth,
+        extractor=extractor,
+        strict_js_required=strict_js_required,
+        config_kwargs=config_kwargs,
+    )
+    async with Fetcher(config) as fetcher:
+        async for _event in fetcher.run():
+            pass
+        stats = fetcher.stats
+        applied_output_dir = fetcher.config.output.directory
+        applied_output_format = fetcher.config.output.format
+    return ScrapeRunResult(
+        start_url=url,
+        output_dir=applied_output_dir,
+        output_format=applied_output_format,
+        stats=stats,
+    )
+
+
+def _site_config(
+    url: str,
+    *,
+    output_dir: Path,
+    output_format: OutputFormat | None,
+    profile: ProfileName,
+    max_pages: int | None,
+    max_depth: int | None,
+    extractor: ExtractorName | None,
+    strict_js_required: bool | None,
+    config_kwargs: dict[str, Any] | None = None,
+) -> DocpullConfig:
+    config_data = dict(config_kwargs or {})
+    config_data.pop("url", None)
+    config_data.pop("profile", None)
+
+    crawl_data = _section_dict(config_data.pop("crawl", None))
+    if max_pages is not None:
+        crawl_data["max_pages"] = max_pages
+    if max_depth is not None:
+        crawl_data["max_depth"] = max_depth
+
+    output_data = _section_dict(config_data.pop("output", None))
+    output_data["directory"] = output_dir
+    if output_format is not None:
+        output_data["format"] = output_format
+
+    content_filter_data = _section_dict(config_data.pop("content_filter", None))
+    if extractor is not None:
+        content_filter_data["extractor"] = extractor
+    if strict_js_required is not None:
+        content_filter_data["strict_js_required"] = strict_js_required
+
+    if crawl_data:
+        config_data["crawl"] = crawl_data
+    if output_data:
+        config_data["output"] = output_data
+    if content_filter_data:
+        config_data["content_filter"] = content_filter_data
+
+    return DocpullConfig(
+        url=url,
+        profile=profile,
+        **config_data,
+    )
+
+
+def _section_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        if isinstance(dumped, dict):
+            return dumped
+    raise TypeError(f"Expected a config section mapping, got {type(value).__name__}")
+
+
+def _merge_config_kwargs(defaults: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(defaults)
+    for key, value in overrides.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(value, dict)
+            and key in {"auth", "cache", "content_filter", "crawl", "network", "output", "performance"}
+        ):
+            nested = dict(merged[key])
+            nested.update(value)
+            merged[key] = nested
+        else:
+            merged[key] = value
+    return merged
+
+
+__all__ = [
+    "ScrapeResult",
+    "ScrapeRunResult",
+    "Scraper",
+    "scrape_one",
+    "scrape_one_blocking",
+    "scrape_site",
+]

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from unittest import mock
+
+from docpull.mcp.sources import default_docs_dir
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
@@ -36,3 +39,15 @@ def test_publish_workflow_is_tag_only() -> None:
     publish = (WORKFLOW_DIR / "publish.yml").read_text()
     assert "workflow_dispatch" not in publish
     assert '"v*.*.*"' in publish
+
+
+def test_plugin_readme_cache_path_matches_mcp_default() -> None:
+    readme = (REPO_ROOT / "plugin" / "README.md").read_text(encoding="utf-8")
+
+    with mock.patch.dict("os.environ", {}, clear=True):
+        default_path = default_docs_dir()
+
+    assert default_path.parts[-2:] == ("docpull-mcp", "docs")
+    assert "$XDG_DATA_HOME/docpull-mcp/docs/" in readme
+    assert "~/.local/share/docpull-mcp/docs/" in readme
+    assert "4.0.0 or newer" in readme

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,35 @@ def test_parser_accepts_supported_naming_strategies():
     assert hierarchical.naming_strategy == "hierarchical"
 
 
+def test_parser_accepts_okf_profile_and_format():
+    parser = create_parser()
+
+    profile = parser.parse_args(["https://example.com", "--profile", "okf"])
+    output_format = parser.parse_args(["https://example.com", "--format", "okf"])
+
+    assert profile.profile == "okf"
+    assert output_format.format == "okf"
+
+
+def test_skill_rejects_okf_output(tmp_path, capsys):
+    parser = create_parser()
+    args = parser.parse_args(
+        [
+            "https://example.com",
+            "--skill",
+            "my-docs",
+            "--format",
+            "okf",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert run_fetcher(args) == 1
+    captured = capsys.readouterr()
+    assert "--skill cannot be combined with OKF output" in captured.out
+
+
 def test_parser_accepts_per_host_concurrency():
     parser = create_parser()
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -325,6 +325,29 @@ class TestFrontmatterBuilder:
         assert 'author: "John Doe"' in result
         assert 'date: "2024-01-01"' in result
 
+    def test_builds_okf_frontmatter(self):
+        """OKF frontmatter includes the required type and recommended resource fields."""
+        builder = FrontmatterBuilder()
+        result = builder.build_okf(
+            title="Getting Started",
+            resource="https://docs.example.com/guide",
+            source="https://docs.example.com/guide",
+            description="Start here.",
+            tags=["docs", "guide"],
+            timestamp="2026-06-12T20:00:00Z",
+            source_type="nextjs",
+        )
+
+        data = yaml.safe_load(result.split("---", 2)[1])
+
+        assert data["type"] == "Documentation Page"
+        assert data["title"] == "Getting Started"
+        assert data["resource"] == "https://docs.example.com/guide"
+        assert data["source"] == "https://docs.example.com/guide"
+        assert data["tags"] == ["docs", "guide"]
+        assert data["timestamp"].isoformat() == "2026-06-12T20:00:00+00:00"
+        assert data["source_type"] == "nextjs"
+
     def test_handles_list_fields(self):
         """Test list fields in frontmatter."""
         builder = FrontmatterBuilder()

--- a/tests/test_document_record.py
+++ b/tests/test_document_record.py
@@ -1,0 +1,53 @@
+"""Tests for stable document and chunk identity."""
+
+from __future__ import annotations
+
+from docpull.models.document import DocumentRecord
+
+
+def test_document_id_is_stable_for_same_url_and_content() -> None:
+    first = DocumentRecord.from_page(
+        url="https://docs.example.com/a",
+        title="A",
+        content="# A\n\nBody",
+    )
+    second = DocumentRecord.from_page(
+        url="https://docs.example.com/a",
+        title="Changed title",
+        content="# A\n\nBody",
+    )
+
+    assert first.document_id == second.document_id
+    assert first.content_hash == second.content_hash
+
+
+def test_document_id_changes_when_content_changes() -> None:
+    first = DocumentRecord.from_page(url="https://docs.example.com/a", content="old")
+    second = DocumentRecord.from_page(url="https://docs.example.com/a", content="new")
+
+    assert first.document_id != second.document_id
+    assert first.content_hash != second.content_hash
+
+
+def test_chunk_id_includes_chunk_position_heading_and_content() -> None:
+    first = DocumentRecord.from_page(
+        url="https://docs.example.com/a",
+        content="same chunk",
+        chunk_index=0,
+        chunk_heading="Install",
+    )
+    same = DocumentRecord.from_page(
+        url="https://docs.example.com/a",
+        content="same chunk",
+        chunk_index=0,
+        chunk_heading="Install",
+    )
+    moved = DocumentRecord.from_page(
+        url="https://docs.example.com/a",
+        content="same chunk",
+        chunk_index=1,
+        chunk_heading="Install",
+    )
+
+    assert first.chunk_id == same.chunk_id
+    assert first.chunk_id != moved.chunk_id

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,6 +44,11 @@ class TestDocpullConfig:
         config = DocpullConfig(url="https://docs.example.com", profile=ProfileName.QUICK)
         assert config.profile == ProfileName.QUICK
 
+    def test_okf_profile(self):
+        """Test OKF profile config."""
+        config = DocpullConfig(url="https://docs.example.com", profile=ProfileName.OKF)
+        assert config.profile == ProfileName.OKF
+
     def test_config_with_crawl_settings(self):
         """Test config with custom crawl settings."""
         config = DocpullConfig(
@@ -385,6 +390,17 @@ class TestProfileDefaults:
         # Quick profile should have low max_pages (50) and max_depth (2)
         assert config.crawl.max_pages == 50
         assert config.crawl.max_depth == 2
+
+    def test_okf_profile_defaults(self):
+        """Test OKF profile applies output defaults."""
+        from docpull.models.profiles import apply_profile
+
+        config = DocpullConfig(url="https://example.com", profile=ProfileName.OKF)
+        config = apply_profile(config)
+
+        assert config.output.format == "okf"
+        assert config.output.rich_metadata is True
+        assert config.content_filter.streaming_dedup is True
 
     def test_explicit_user_value_beats_profile_value(self):
         """User-supplied values must win over profile values on collision.

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from docpull.core.fetcher import Fetcher, _url_to_filename, _url_to_path_parts
+from docpull.core.fetcher import Fetcher, _url_to_filename, _url_to_okf_path_parts, _url_to_path_parts
 from docpull.models.config import DocpullConfig
 
 
@@ -53,6 +53,22 @@ class TestHierarchicalPathParts:
         assert "index" in result or result == ["api.md"]
 
 
+class TestOkfPathParts:
+    """Test URL conversion for OKF concept filenames."""
+
+    def test_root_url_avoids_reserved_index(self) -> None:
+        assert _url_to_okf_path_parts("https://docs.foo.com/") == ["_root.md"]
+
+    def test_trailing_slash_avoids_reserved_index(self) -> None:
+        assert _url_to_okf_path_parts("https://docs.foo.com/api/") == ["api", "_page.md"]
+
+    def test_index_html_avoids_reserved_index(self) -> None:
+        assert _url_to_okf_path_parts("https://docs.foo.com/api/index.html") == ["api", "_page.md"]
+
+    def test_log_html_avoids_reserved_log(self) -> None:
+        assert _url_to_okf_path_parts("https://docs.foo.com/log.html") == ["_log.md"]
+
+
 class TestComputeOutputPath:
     """Test that Fetcher routes to the right strategy."""
 
@@ -83,6 +99,15 @@ class TestComputeOutputPath:
         fetcher = Fetcher(config)
         path = fetcher._compute_output_path("https://docs.foo.com/api/")
         assert path == tmp_path / "api" / "index.md"
+
+    def test_okf_format_uses_okf_safe_paths(self, tmp_path: Path) -> None:
+        config = DocpullConfig(
+            url="https://docs.foo.com/",
+            output={"directory": tmp_path, "format": "okf"},
+        )
+        fetcher = Fetcher(config)
+        path = fetcher._compute_output_path("https://docs.foo.com/api/")
+        assert path == tmp_path / "api" / "_page.md"
 
 
 class TestFlattenedFilename:

--- a/tests/test_outputs_e2e.py
+++ b/tests/test_outputs_e2e.py
@@ -223,7 +223,7 @@ async def test_okf_output_bundle_local_server(output_server: str, tmp_path: Path
     assert "# Alpha" in concept
 
     root_index = (tmp_path / "index.md").read_text()
-    assert root_index.startswith("---\nokf_version: \"0.1\"\n---")
+    assert root_index.startswith('---\nokf_version: "0.1"\n---')
     assert "* [Alpha Docs](_root.md)" in root_index
 
     manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
@@ -249,7 +249,7 @@ async def test_okf_indexes_include_nested_directories(tmp_path: Path) -> None:
     root_index = (tmp_path / "index.md").read_text()
     nested_index = (tmp_path / "api" / "index.md").read_text()
 
-    assert root_index.startswith("---\nokf_version: \"0.1\"\n---")
+    assert root_index.startswith('---\nokf_version: "0.1"\n---')
     assert "* [api](api/) - 1 concept" in root_index
     assert not nested_index.startswith("---")
     assert "* [API](_page.md)" in nested_index

--- a/tests/test_outputs_e2e.py
+++ b/tests/test_outputs_e2e.py
@@ -7,10 +7,16 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+import yaml
 from aiohttp import web
+from pydantic import ValidationError
 
+from docpull import ProfileName, Scraper, scrape_one
+from docpull.conversion.special_cases import _split_markdown_frontmatter
 from docpull.core.fetcher import Fetcher
 from docpull.models.config import DocpullConfig
+from docpull.pipeline.base import PageContext
+from docpull.pipeline.steps.save_okf import OkfSaveStep
 from docpull.security.robots import RobotsChecker
 from docpull.security.url_validator import UrlValidator
 
@@ -53,6 +59,44 @@ async def output_server(monkeypatch: pytest.MonkeyPatch):
     await runner.cleanup()
 
 
+@pytest.fixture
+async def user_agent_server(monkeypatch: pytest.MonkeyPatch):
+    seen: dict[str, str | None] = {}
+
+    async def page(request: web.Request) -> web.Response:
+        seen["user_agent"] = request.headers.get("User-Agent")
+        return web.Response(body=PAGE_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/", page)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+
+    def permissive_validate(self, hostname):  # type: ignore[no-untyped-def]
+        from docpull.security.url_validator import UrlValidationResult
+
+        return UrlValidationResult.valid()
+
+    original_init = UrlValidator.__init__
+
+    def init_with_http(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["allowed_schemes"] = {"http", "https"}
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(UrlValidator, "validate_hostname", permissive_validate)
+    monkeypatch.setattr(UrlValidator, "__init__", init_with_http)
+    monkeypatch.setattr(RobotsChecker, "is_allowed", lambda self, url: True)
+    monkeypatch.setattr(RobotsChecker, "get_sitemaps", lambda self, url: [])
+    monkeypatch.setattr(RobotsChecker, "get_crawl_delay", lambda self, url: None)
+
+    yield f"http://127.0.0.1:{port}/", seen
+
+    await runner.cleanup()
+
+
 async def _run_single(url: str, output_dir: Path, output: dict[str, object]) -> None:
     cfg = DocpullConfig(
         url=url,
@@ -61,6 +105,37 @@ async def _run_single(url: str, output_dir: Path, output: dict[str, object]) -> 
     )
     async with Fetcher(cfg) as fetcher:
         await fetcher.fetch_one(url)
+
+
+def assert_okf_bundle_conformant(bundle_dir: Path) -> None:
+    """Assert the generated bundle meets OKF v0.1's hard conformance rules."""
+    concept_count = 0
+    for path in bundle_dir.rglob("*.md"):
+        rel = path.relative_to(bundle_dir).as_posix()
+        text = path.read_text(encoding="utf-8")
+        frontmatter, body = _split_markdown_frontmatter(text)
+        if path.name == "index.md":
+            if rel == "index.md" and frontmatter is not None:
+                data = yaml.safe_load(frontmatter)
+                assert data == {"okf_version": "0.1"}
+                assert body.strip()
+            else:
+                assert frontmatter is None
+                assert text.strip()
+            continue
+        if path.name == "log.md":
+            assert frontmatter is None
+            assert text.startswith("# ")
+            continue
+
+        concept_count += 1
+        assert frontmatter is not None, rel
+        data = yaml.safe_load(frontmatter)
+        assert isinstance(data, dict), rel
+        assert isinstance(data.get("type"), str) and data["type"].strip(), rel
+        assert body.strip(), rel
+
+    assert concept_count > 0
 
 
 @pytest.mark.asyncio
@@ -78,6 +153,18 @@ async def test_json_output_schema_local_server(output_server: str, tmp_path: Pat
     assert manifest["output_format"] == "json"
     assert manifest["document_count"] == 1
     assert manifest["records"][0]["document_id"] == record["document_id"]
+
+
+@pytest.mark.asyncio
+async def test_markdown_output_writes_manifest(output_server: str, tmp_path: Path) -> None:
+    await _run_single(output_server, tmp_path, {"format": "markdown"})
+
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
+
+    assert manifest["output_format"] == "markdown"
+    assert manifest["document_count"] == 1
+    assert manifest["records"][0]["output_path"] == "index.md"
+    assert manifest["records"][0]["content_hash"]
 
 
 @pytest.mark.asyncio
@@ -101,6 +188,7 @@ async def test_ndjson_chunk_output_local_server(output_server: str, tmp_path: Pa
     assert manifest["output_format"] == "ndjson"
     assert manifest["chunk_count"] == len(lines)
     assert manifest["records"][0]["chunk_id"] == lines[0]["chunk_id"]
+    assert manifest["records"][0]["output_path"] == "docs.ndjson"
 
 
 @pytest.mark.asyncio
@@ -118,3 +206,152 @@ async def test_sqlite_output_schema_local_server(output_server: str, tmp_path: P
     manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
     assert manifest["output_format"] == "sqlite"
     assert manifest["record_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_okf_output_bundle_local_server(output_server: str, tmp_path: Path) -> None:
+    await _run_single(output_server, tmp_path, {"format": "okf"})
+
+    concept_path = tmp_path / "_root.md"
+    concept = concept_path.read_text()
+    assert concept.startswith("---\n")
+    frontmatter = yaml.safe_load(concept.split("---", 2)[1])
+    assert frontmatter["type"] == "Documentation Page"
+    assert frontmatter["title"] == "Alpha Docs"
+    assert frontmatter["resource"] == output_server
+    assert frontmatter["source"] == output_server
+    assert "# Alpha" in concept
+
+    root_index = (tmp_path / "index.md").read_text()
+    assert root_index.startswith("---\nokf_version: \"0.1\"\n---")
+    assert "* [Alpha Docs](_root.md)" in root_index
+
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text())
+    assert manifest["output_format"] == "okf"
+    assert manifest["record_count"] == 1
+    assert manifest["records"][0]["output_path"] == "_root.md"
+    assert_okf_bundle_conformant(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_okf_indexes_include_nested_directories(tmp_path: Path) -> None:
+    step = OkfSaveStep(tmp_path)
+    ctx = PageContext(
+        url="https://docs.example.com/api/",
+        output_path=tmp_path / "api" / "_page.md",
+    )
+    ctx.title = "API"
+    ctx.markdown = "# API\n\nBody."
+
+    await step.execute(ctx)
+    step.finalize()
+
+    root_index = (tmp_path / "index.md").read_text()
+    nested_index = (tmp_path / "api" / "index.md").read_text()
+
+    assert root_index.startswith("---\nokf_version: \"0.1\"\n---")
+    assert "* [api](api/) - 1 concept" in root_index
+    assert not nested_index.startswith("---")
+    assert "* [API](_page.md)" in nested_index
+    assert_okf_bundle_conformant(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_scrape_one_api_returns_in_memory_markdown(output_server: str) -> None:
+    result = await scrape_one(output_server)
+
+    assert result.url == output_server
+    assert result.title == "Alpha Docs"
+    assert result.markdown
+    assert "# Alpha" in result.text
+    assert result.error is None
+    assert result.skipped is False
+    assert result.extraction["confidence"] > 0
+
+
+@pytest.mark.asyncio
+async def test_scrape_one_api_does_not_write_default_docs_dir(
+    output_server: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = await scrape_one(output_server)
+
+    assert result.markdown
+    assert not (tmp_path / "docs").exists()
+
+
+@pytest.mark.asyncio
+async def test_scrape_one_api_ignores_existing_default_output_file(
+    output_server: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "index.md").write_text("old content", encoding="utf-8")
+
+    result = await scrape_one(output_server)
+
+    assert result.skipped is False
+    assert result.markdown
+    assert "# Alpha" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_scrape_one_api_forwards_docpull_config_kwargs(
+    user_agent_server: tuple[str, dict[str, str | None]],
+) -> None:
+    url, seen = user_agent_server
+
+    result = await scrape_one(url, network={"user_agent": "docpull-test-agent"})
+
+    assert result.markdown
+    assert seen["user_agent"] == "docpull-test-agent"
+
+
+@pytest.mark.asyncio
+async def test_scraper_facade_writes_site_outputs(output_server: str, tmp_path: Path) -> None:
+    scraper = Scraper()
+
+    result = await scraper.scrape_site(
+        output_server,
+        output_dir=tmp_path,
+        output_format="ndjson",
+        max_pages=1,
+    )
+
+    assert result.stats.pages_fetched == 1
+    assert result.manifest_path.exists()
+    assert (tmp_path / "documents.ndjson").exists()
+
+
+@pytest.mark.asyncio
+async def test_scraper_facade_preserves_profile_output_defaults(output_server: str, tmp_path: Path) -> None:
+    scraper = Scraper()
+
+    result = await scraper.scrape_site(
+        output_server,
+        output_dir=tmp_path,
+        profile=ProfileName.OKF,
+        max_pages=1,
+    )
+
+    assert result.output_format == "okf"
+    assert result.manifest_path.exists()
+    assert (tmp_path / "_root.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_scraper_facade_rejects_invalid_crawl_depth(output_server: str, tmp_path: Path) -> None:
+    scraper = Scraper()
+
+    with pytest.raises(ValidationError):
+        await scraper.scrape_site(
+            output_server,
+            output_dir=tmp_path,
+            max_depth=0,
+        )

--- a/tests/test_save_ndjson.py
+++ b/tests/test_save_ndjson.py
@@ -41,6 +41,26 @@ async def test_ndjson_writes_one_line_per_page(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_ndjson_manifest_marks_stdout_stream(tmp_path, capsys):
+    step = NdjsonSaveStep(base_output_dir=tmp_path, filename="-")
+    ctx = PageContext(
+        url="https://example.com/stdout",
+        output_path=tmp_path / "stdout.md",
+        markdown="# Stdout\n\nBody.",
+        title="Stdout",
+    )
+
+    await step.execute(ctx)
+    out_path = step.finalize()
+
+    captured = capsys.readouterr()
+    assert out_path is None
+    assert '"url": "https://example.com/stdout"' in captured.out
+    manifest = json.loads((tmp_path / "corpus.manifest.json").read_text(encoding="utf-8"))
+    assert manifest["records"][0]["output_path"] == "-"
+
+
+@pytest.mark.asyncio
 async def test_ndjson_emits_chunks_when_enabled(tmp_path):
     step = NdjsonSaveStep(base_output_dir=tmp_path, filename="out.ndjson", emit_chunks=True)
     ctx = PageContext(

--- a/tests/test_save_sqlite.py
+++ b/tests/test_save_sqlite.py
@@ -7,7 +7,7 @@ import sqlite3
 import pytest
 
 from docpull.pipeline.base import PageContext
-from docpull.pipeline.steps.save_sqlite import SqliteSaveStep
+from docpull.pipeline.steps.save_sqlite import SqliteSaveStep, search_sqlite_documents
 
 
 @pytest.mark.asyncio
@@ -48,5 +48,37 @@ async def test_sqlite_save_migrates_legacy_documents_table(tmp_path):
         assert row[0] == "https://example.com/page"
         assert row[1] == 1
         assert row[2]
+        fts_row = conn.execute("SELECT url FROM documents_fts WHERE documents_fts MATCH 'Body'").fetchone()
+        assert fts_row == ("https://example.com/page",)
     finally:
         conn.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_output_is_full_text_searchable(tmp_path):
+    step = SqliteSaveStep(tmp_path)
+    ctx = PageContext(
+        url="https://example.com/install",
+        output_path=tmp_path / "install.md",
+        markdown="# Install\n\nUse the orbital wrench package manager for setup.",
+        title="Install",
+    )
+
+    await step.execute(ctx)
+    step.close()
+
+    hits = search_sqlite_documents(tmp_path / "documents.db", "orbital")
+
+    assert len(hits) == 1
+    assert hits[0].url == "https://example.com/install"
+    assert hits[0].title == "Install"
+    assert "[orbital]" in hits[0].snippet
+
+
+def test_sqlite_search_missing_database_returns_empty_without_creating_file(tmp_path):
+    db_path = tmp_path / "missing.db"
+
+    hits = search_sqlite_documents(db_path, "anything")
+
+    assert hits == []
+    assert not db_path.exists()

--- a/tests/test_special_cases.py
+++ b/tests/test_special_cases.py
@@ -9,11 +9,17 @@ import pytest
 from docpull.conversion.special_cases import (
     DEFAULT_CHAIN,
     DocusaurusExtractor,
+    GitBookExtractor,
     MintlifyExtractor,
+    MkDocsMaterialExtractor,
     NextDataExtractor,
     OpenApiExtractor,
     RawTextExtractor,
+    ReadMeExtractor,
+    RedocScalarExtractor,
     SpecialCaseResult,
+    StarlightExtractor,
+    VitePressExtractor,
     detect_source_type,
     looks_like_spa,
 )
@@ -76,6 +82,125 @@ class TestNextDataExtractor:
         assert result is not None
         assert "Readable markdown body" in result.markdown
         assert "function MDXContent" not in result.markdown
+
+
+class TestStaticFrameworkExtractors:
+    @pytest.mark.parametrize(
+        ("extractor", "head_marker", "selector_open", "selector_close", "source_type", "framework"),
+        [
+            (
+                MkDocsMaterialExtractor(),
+                '<meta name="generator" content="mkdocs">',
+                '<article class="md-content__inner">',
+                "</article>",
+                "mkdocs",
+                "mkdocs",
+            ),
+            (
+                VitePressExtractor(),
+                '<meta name="generator" content="VitePress">',
+                '<div class="VPDoc"><div class="content vp-doc">',
+                "</div></div>",
+                "vitepress",
+                "vitepress",
+            ),
+            (
+                StarlightExtractor(),
+                '<meta name="generator" content="astro starlight">',
+                '<main class="sl-markdown-content">',
+                "</main>",
+                "starlight",
+                "starlight",
+            ),
+            (
+                GitBookExtractor(),
+                '<meta name="generator" content="gitbook">',
+                '<main data-testid="page.content">',
+                "</main>",
+                "gitbook",
+                "gitbook",
+            ),
+            (
+                ReadMeExtractor(),
+                '<meta property="og:site_name" content="readme.io">',
+                '<article class="rm-markdown">',
+                "</article>",
+                "readme",
+                "readme",
+            ),
+            (
+                RedocScalarExtractor(),
+                '<meta name="generator" content="redoc">',
+                '<main class="api-content">',
+                "</main>",
+                "api_reference",
+                "redoc_scalar",
+            ),
+        ],
+    )
+    def test_common_static_framework_extractors(
+        self,
+        extractor,
+        head_marker: str,
+        selector_open: str,
+        selector_close: str,
+        source_type: str,
+        framework: str,
+    ):
+        html = (
+            "<!doctype html><html><head><title>Framework Guide</title>"
+            f"{head_marker}</head><body>{selector_open}"
+            "<h1>Framework Guide</h1>"
+            "<p>Rendered documentation content is available in static HTML.</p>"
+            + ("<p>Reference paragraph for local context extraction.</p>" * 4)
+            + f"{selector_close}</body></html>"
+        ).encode()
+
+        result = extractor.try_extract(html, "https://docs.example.com/framework")
+
+        assert result is not None
+        assert result.source_type == source_type
+        assert result.extra == {"framework": framework}
+        assert result.title == "Framework Guide"
+        assert "# Framework Guide" in result.markdown
+
+    def test_docusaurus_extracts_static_article_and_tags_framework(self):
+        html = (
+            b"<!doctype html><html><head>"
+            b'<meta name="generator" content="Docusaurus v3">'
+            b"<title>Docusaurus Intro</title></head><body>"
+            b'<div id="__docusaurus"><main><article>'
+            b"<h1>Intro</h1><p>Docusaurus content renders statically for extraction.</p>"
+            + (b"<p>Body paragraph for documentation users.</p>" * 4)
+            + b"</article></main></div></body></html>"
+        )
+
+        result = DocusaurusExtractor().try_extract(html, "https://docs.example.com/intro")
+
+        assert result is not None
+        assert result.source_type == "docusaurus"
+        assert result.extra == {"framework": "docusaurus"}
+        assert result.title == "Docusaurus Intro"
+        assert "# Intro" in result.markdown
+
+    def test_sphinx_extracts_static_body_and_tags_framework(self):
+        html = (
+            b"<!doctype html><html><head>"
+            b'<meta name="generator" content="Sphinx 8.0">'
+            b"<title>Sphinx API</title></head><body>"
+            b'<div class="document"><div class="body" role="main">'
+            b"<h1>Sphinx API</h1><p>Sphinx content is server-rendered HTML.</p>"
+            + (b"<p>Reference paragraph for generated docs.</p>" * 4)
+            + b"</div></div></body></html>"
+        )
+
+        result = DEFAULT_CHAIN[-1].try_extract(html, "https://pkg.readthedocs.io/en/latest/api.html")
+
+        assert result is not None
+        assert result.source_type == "sphinx"
+        assert result.extra == {"framework": "sphinx"}
+        assert result.title == "Sphinx API"
+        assert "# Sphinx API" in result.markdown
 
 
 class TestOpenApiExtractor:

--- a/tests/test_special_cases.py
+++ b/tests/test_special_cases.py
@@ -515,6 +515,15 @@ class TestDetectSourceType:
     def test_readthedocs_host_assumes_sphinx(self):
         assert detect_source_type(b"<html></html>", "https://foo.readthedocs.io/page") == "sphinx"
 
+    def test_deceptive_readthedocs_suffix_is_generic(self):
+        assert detect_source_type(b"<html></html>", "https://readthedocs.io.evil.example/page") == "generic"
+
+    def test_readme_host_assumes_readme(self):
+        assert detect_source_type(b"<html></html>", "https://docs.readme.io/page") == "readme"
+
+    def test_deceptive_readme_suffix_is_generic(self):
+        assert detect_source_type(b"<html></html>", "https://readme.io.evil.example/page") == "generic"
+
 
 class TestDefaultChain:
     def test_chain_has_expected_extractors(self):


### PR DESCRIPTION
## Summary
- add first-class OKF output via --format okf / --profile okf
- add generated OKF indexes, corpus manifest docs, scraper-facing API, and SQLite/search output docs
- expand tests for OKF bundle shape, naming collisions, manifests, and scraper/document records

## Validation
- uv run ruff check .
- uv run mypy src/docpull
- uv run pytest
- uv build

Note: this PR does not publish PyPI. The package version remains 4.2.0 until an explicit release bump/publish.