### PR TITLE
Release docpull 4.3.0

### DIFF
--- a/audit/00_EXECUTIVE_SUMMARY.md
+++ b/audit/00_EXECUTIVE_SUMMARY.md
@@ -15,22 +15,21 @@ internal Bun/TypeScript MCP lab tree.
 
 Current audit target evidence:
 
-- `pyproject.toml` declares package `docpull` version `4.2.0`.
-- `.venv/bin/python -m pip show docpull` reports version `4.2.0` with editable
-  project location `/Users/mb1/Code/raintree/docpull`.
-- Git `HEAD` is `a6cce31`.
-- The current worktree is dirty because unreleased OKF, scraper API, SQLite
-  FTS, framework extractor, docs, and audit updates are in progress.
+- `pyproject.toml` declares package `docpull` version `4.3.0`.
+- `uv run docpull --version` reports `docpull 4.3.0`.
+- Git `HEAD` is `4a3b3b5`.
+- The release branch contains the 4.3.0 version, changelog, and audit updates.
 
 ## What Works
 
 Current local verification:
 
-- `.venv/bin/pytest -q` passed: 522 tests.
-- `.venv/bin/mypy src/docpull` passed: 73 source files.
-- `.venv/bin/ruff check .` passed.
-- `.venv/bin/python -m docpull --version` reports `docpull 4.2.0`.
-- `.venv/bin/python -m docpull --help`, `--doctor`, and `mcp --help` pass.
+- `uv run pytest` passed: 532 tests.
+- `uv run mypy src/docpull` passed: 73 source files.
+- `uv run ruff check .` passed.
+- `uv run ruff format --check .` passed.
+- `uv run docpull --version` reports `docpull 4.3.0`.
+- `uv run --extra dev python -m pre_commit run --all-files --show-diff-on-failure` passed.
 
 Implemented and covered by tests:
 

--- a/audit/02_FUNCTIONALITY_MATRIX.md
+++ b/audit/02_FUNCTIONALITY_MATRIX.md
@@ -2,7 +2,7 @@
 
 | Feature | Documented? | Implemented? | Tested? | Current status | Evidence / next step |
 | --- | ---: | ---: | ---: | --- | --- |
-| Package version 4.2.0 | Yes | Yes | Smoke | Working | `pyproject.toml`; `.venv/bin/python -m docpull --version` |
+| Package version 4.3.0 | Yes | Yes | Smoke | Working | `pyproject.toml`; `.venv/bin/python -m docpull --version` |
 | CLI `--help` / `--version` | Yes | Yes | Smoke | Working | Final release gate should rerun direct CLI smoke |
 | Profiles `rag/mirror/quick/llm/okf` | Yes | Yes | Yes | Working | Profile tests and CLI parser tests |
 | `--single` in-memory fast path | Yes | Yes | Yes | Working | Fetcher and scraper API e2e tests |

--- a/audit/04_TEST_PLAN.md
+++ b/audit/04_TEST_PLAN.md
@@ -3,7 +3,7 @@
 ## Current Inventory
 
 - Python source files: 73 checked by mypy.
-- Test suite: 522 tests passing in the current checkout.
+- Test suite: 532 tests passing in the current checkout.
 - Categories present: CLI, config, integration, discovery, link extractors,
   conversion, special cases, pipeline, output formats, OKF, scraper API,
   chunking, cache conditional GET, frontier/resume, MCP tools/server, security
@@ -12,26 +12,25 @@
 
 ## Current Baseline Results
 
-- `.venv/bin/pytest -q`: passed, 522 tests.
-- `.venv/bin/mypy src/docpull`: passed, 73 source files.
-- `.venv/bin/ruff check .`: passed.
-- `.venv/bin/python -m docpull --version`: passed, `docpull 4.2.0`.
-- `.venv/bin/python -m docpull --help`, `--doctor`, and `mcp --help`: passed.
-- `.venv/bin/pytest`, `.venv/bin/mypy`, and editable `docpull` console setup now
-  point at `/Users/mb1/Code/raintree/docpull` instead of the stale secondary
-  checkout.
+- `uv run pytest`: passed, 532 tests.
+- `uv run mypy src/docpull`: passed, 73 source files.
+- `uv run ruff check .`: passed.
+- `uv run ruff format --check .`: passed.
+- `uv run docpull --version`: passed, `docpull 4.3.0`.
+- `uv run --extra dev python -m pre_commit run --all-files --show-diff-on-failure`: passed.
 
 ## Required Release Gate
 
 P0:
 
-- `.venv/bin/ruff check .`
-- `.venv/bin/mypy src/docpull`
-- `.venv/bin/pytest -q`
-- `.venv/bin/python -m docpull --version`
-- `.venv/bin/python -m docpull --help`
-- `.venv/bin/python -m docpull --doctor`
-- `.venv/bin/python -m docpull mcp --help`
+- `uv run ruff check .`
+- `uv run ruff format --check .`
+- `uv run mypy src/docpull`
+- `uv run pytest`
+- `uv run docpull --version`
+- `uv run docpull --help`
+- `uv run docpull --doctor`
+- `uv run docpull mcp --help`
 
 ## Missing or Weak Test Areas
 

--- a/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
+++ b/audit/08_CLAIM_IMPLEMENTATION_GAPS.md
@@ -4,7 +4,7 @@
 
 | Claim / gap | Current evidence | Status |
 | --- | --- | --- |
-| Runtime supports CLI help/version | `.venv/bin/python -m docpull --version` reports `docpull 4.2.0`; help works through the same import path | Resolved |
+| Runtime supports CLI help/version | `.venv/bin/python -m docpull --version` reports `docpull 4.3.0`; help works through the same import path | Resolved |
 | Local editable install points at this checkout | `.venv/bin/python -m pip show docpull` reports editable project location `/Users/mb1/Code/raintree/docpull` | Resolved |
 | `flat`/`short` naming aliases removed in 3.0 | CLI help now lists only `full` and `hierarchical`; config allows only those literals | Resolved |
 | LLM profile JS policy is ambiguous | `profiles.py` documents that LLM mode skips JS-only pages by default; `--strict-js-required` remains the explicit fail-loud option | Resolved |

--- a/audit/10_AGENT_CONTEXT_BRIEF.md
+++ b/audit/10_AGENT_CONTEXT_BRIEF.md
@@ -1,6 +1,6 @@
 # Agent Context Brief
 
-DocPull is a Python 3.10+ package/CLI at version 4.2.0. It is a browser-free
+DocPull is a Python 3.10+ package/CLI at version 4.3.0. It is a browser-free
 web scraper for static/server-rendered docs and pages, with agent-context output
 formats: Markdown, JSON, NDJSON, SQLite, OKF, manifests, source indexes, and
 MCP tools. The repo also contains optional Parallel provider workflows, a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-06-14
+
 ### Added
 - Add first-class Open Knowledge Format output via `--format okf` and
   `--profile okf`, including OKF concept frontmatter, generated directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "4.2.0"
+version = "4.3.0"
 dynamic = []
 description = "Pull documentation from the web and convert to clean markdown"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .conversion.chunking import Chunk, TokenCounter, chunk_markdown


### PR DESCRIPTION
## Summary
- bump DocPull package version to 4.3.0
- add the 4.3.0 changelog entry for OKF output
- refresh audit/version references for the release

## Validation
- uv run docpull --version
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/docpull
- uv run pytest (532 passed)
- uv run --extra dev python -m pre_commit run --all-files --show-diff-on-failure
- uv build
- uvx twine check dist/*