### PR TITLE
Remove unhelpful narration comments

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -450,7 +450,6 @@ server.tool(
 		}
 		const needsIndex = index && isDbConfigured() && openai !== null;
 
-		// Return early if cached and indexed
 		if (!needsFetch && cache.exists && (!needsIndex || cache.indexed)) {
 			return {
 				content: [

--- a/src/docpull/conversion/extractor.py
+++ b/src/docpull/conversion/extractor.py
@@ -196,12 +196,10 @@ class MainContentExtractor:
         keep_attrs = {"href", "src", "alt", "title", "class", "id"}
 
         for tag in element.find_all(True):
-            # Get list of attrs to remove (can't modify during iteration)
             attrs_to_remove = [attr for attr in tag.attrs if attr not in keep_attrs]
             for attr in attrs_to_remove:
                 del tag[attr]
 
-            # Remove empty class/id
             if tag.get("class") == []:
                 del tag["class"]
             if tag.get("id") == "":
@@ -211,7 +209,6 @@ class MainContentExtractor:
         """Convert relative URLs to absolute URLs."""
         urlparse(base_url)
 
-        # Resolve href attributes
         for tag in element.find_all("a", href=True):
             href = tag["href"]
             if href.startswith("#"):
@@ -219,7 +216,6 @@ class MainContentExtractor:
             if not href.startswith(("http://", "https://", "//")):
                 tag["href"] = urljoin(base_url, href)
 
-        # Resolve src attributes
         for tag in element.find_all(src=True):
             src = tag["src"]
             if not src.startswith(("http://", "https://", "//", "data:")):
@@ -227,11 +223,8 @@ class MainContentExtractor:
 
     def _clean_whitespace(self, text: str) -> str:
         """Clean up excessive whitespace."""
-        # Normalize line endings
         text = text.replace("\r\n", "\n").replace("\r", "\n")
-        # Remove excessive blank lines (more than 2)
         text = re.sub(r"\n{3,}", "\n\n", text)
-        # Remove trailing whitespace on lines
         text = "\n".join(line.rstrip() for line in text.split("\n"))
         return text.strip()
 
@@ -248,7 +241,6 @@ class MainContentExtractor:
         """
         soup = self._parse_html(html)
 
-        # Find main content
         main_content = self._find_main_content(soup)
         if main_content is None:
             # Try the entire document as fallback
@@ -261,7 +253,6 @@ class MainContentExtractor:
         # Make a copy to avoid modifying original
         content = BeautifulSoup(str(main_content), "html.parser")
 
-        # Clean up
         # Math-rendering libraries often hide the source TeX in script,
         # MathML annotation, or aria-hidden wrappers that the generic cleanup
         # removes. Normalize those to Markdown text before deleting chrome.

--- a/src/docpull/conversion/markdown.py
+++ b/src/docpull/conversion/markdown.py
@@ -384,13 +384,10 @@ class HtmlToMarkdown:
         markdown = _restore_latex_math_delimiters(markdown)
         markdown = _rewrite_markdown_links(markdown, _normalize_protected_absolute_destination)
 
-        # Remove excessive blank lines
         markdown = re.sub(r"\n{3,}", "\n\n", markdown)
 
-        # Remove trailing whitespace on each line
         markdown = "\n".join(line.rstrip() for line in markdown.split("\n"))
 
-        # Ensure single newline at end
         return markdown.strip() + "\n"
 
     def _fix_relative_links(self, markdown: str, base_url: str) -> str:
@@ -412,13 +409,10 @@ class HtmlToMarkdown:
             Markdown string
         """
         try:
-            # Set base URL for link resolution
             self._converter.baseurl = url
 
-            # Convert to markdown
             markdown = self._converter.handle(html)
 
-            # Clean up output
             markdown = self._clean_output(markdown)
 
             # Fix any remaining relative links

--- a/src/docpull/core/fetcher.py
+++ b/src/docpull/core/fetcher.py
@@ -54,23 +54,18 @@ def _url_to_filename(url: str, base_url: str | None = None) -> str:
     parsed = urlparse(url)
     path = parsed.path.strip("/")
 
-    # Remove base URL prefix if provided
     if base_url:
         base_path = urlparse(base_url).path.strip("/")
         if path.startswith(base_path):
             path = path[len(base_path) :].strip("/")
 
-    # Convert path to filename
     if not path or path == "/":
         filename = "index"
     else:
-        # Replace path separators with underscores
         filename = path.replace("/", "_")
-        # Remove file extension if present
         if filename.endswith(".html") or filename.endswith(".htm"):
             filename = filename.rsplit(".", 1)[0]
 
-    # Clean up filename
     filename = re.sub(r"[^\w\-]", "_", filename)
     filename = re.sub(r"_+", "_", filename)
     filename = filename.strip("_")

--- a/src/docpull/discovery/link_extractors/enhanced.py
+++ b/src/docpull/discovery/link_extractors/enhanced.py
@@ -274,16 +274,13 @@ class EnhancedLinkExtractor:
             logger.debug("Could not resolve href %r against %s: %s", href, base_url, err)
             return None
 
-        # Validate it's a proper URL
         parsed = urlparse(absolute_url)
         if not parsed.scheme or not parsed.netloc:
             return None
 
-        # Only allow http/https
         if parsed.scheme not in ("http", "https"):
             return None
 
-        # Remove fragment
         clean_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
         if parsed.query:
             clean_url += f"?{parsed.query}"

--- a/src/docpull/discovery/link_extractors/static.py
+++ b/src/docpull/discovery/link_extractors/static.py
@@ -126,7 +126,6 @@ class StaticLinkExtractor:
             logger.debug("Could not resolve href %r against %s: %s", href, base_url, err)
             return None
 
-        # Remove fragment
         parsed = urlparse(absolute_url)
         clean_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
         if parsed.query:

--- a/src/docpull/discovery/sitemap.py
+++ b/src/docpull/discovery/sitemap.py
@@ -170,12 +170,10 @@ class SitemapDiscoverer:
             ns = SITEMAP_NS if use_ns else {}
             prefix = "ns:" if use_ns else ""
 
-            # Find page URLs
             for url_elem in root.findall(f".//{prefix}url/{prefix}loc", ns):
                 if url_elem.text:
                     page_urls.append(url_elem.text.strip())
 
-            # Find nested sitemap URLs
             for sitemap_elem in root.findall(f".//{prefix}sitemap/{prefix}loc", ns):
                 if sitemap_elem.text:
                     sitemap_urls.append(sitemap_elem.text.strip())
@@ -229,14 +227,12 @@ class SitemapDiscoverer:
             if self._filter and not self._filter.should_include(url):
                 continue
 
-            # Skip duplicates
             if not self._seen.add(url):
                 continue
 
             yield url
             count += 1
 
-        # Process nested sitemaps
         remaining = max_urls - count if max_urls is not None else None
         for nested_url in nested_sitemaps:
             if remaining is not None and remaining <= 0:

--- a/src/docpull/metadata_extractor.py
+++ b/src/docpull/metadata_extractor.py
@@ -59,7 +59,6 @@ class RichMetadataExtractor:
         try:
             import extruct
 
-            # Extract all structured data
             data = extruct.extract(
                 html,
                 base_url=url,
@@ -67,19 +66,16 @@ class RichMetadataExtractor:
                 errors="ignore",
             )
 
-            # Extract Open Graph data
             og_data = data.get("opengraph", [])
             if og_data and isinstance(og_data, list) and len(og_data) > 0:
                 og = og_data[0].get("properties", [])
                 if og:
                     metadata.update(self._extract_opengraph(og))  # type: ignore[typeddict-item]
 
-            # Extract JSON-LD data
             jsonld_data = data.get("json-ld", [])
             if jsonld_data and isinstance(jsonld_data, list):
                 metadata.update(self._extract_jsonld(jsonld_data))  # type: ignore[typeddict-item]
 
-            # Extract microdata
             microdata = data.get("microdata", [])
             if microdata and isinstance(microdata, list):
                 metadata.update(self._extract_microdata(microdata))  # type: ignore[typeddict-item]
@@ -102,7 +98,6 @@ class RichMetadataExtractor:
         """
         result: dict[str, Any] = {}
 
-        # Build dict from properties list
         og_dict: dict[str, Any] = {}
         for prop in og_properties:
             if isinstance(prop, dict):
@@ -170,7 +165,6 @@ class RichMetadataExtractor:
             if not isinstance(item, dict):
                 continue
 
-            # Extract common fields
             if "headline" in item and not result.get("title"):
                 result["title"] = self._safe_string(item["headline"])
 
@@ -193,7 +187,6 @@ class RichMetadataExtractor:
             if "keywords" in item and not result.get("keywords"):
                 keywords = item["keywords"]
                 if isinstance(keywords, str):
-                    # Split comma-separated keywords
                     result["keywords"] = [k.strip() for k in keywords.split(",") if k.strip()]
                 elif isinstance(keywords, list):
                     result["keywords"] = [self._safe_string(k) for k in keywords if k]
@@ -226,7 +219,6 @@ class RichMetadataExtractor:
             if not properties:
                 continue
 
-            # Extract relevant fields
             if "headline" in properties and not result.get("title"):
                 result["title"] = self._safe_string(properties["headline"])
 
@@ -275,11 +267,9 @@ class RichMetadataExtractor:
         """
         result: dict[str, Any] = dict(rich_metadata)
 
-        # Use fallback title if no title found
         if not result.get("title") and fallback_title:
             result["title"] = fallback_title
 
-        # Clean up empty values
         result = {k: v for k, v in result.items() if v}
 
         return result

--- a/src/docpull/pipeline/steps/metadata.py
+++ b/src/docpull/pipeline/steps/metadata.py
@@ -97,26 +97,21 @@ class MetadataStep:
             return ctx
 
         try:
-            # Parse HTML
             soup = BeautifulSoup(ctx.html, "html.parser")
 
-            # Extract basic metadata
             ctx.title = self._extract_title(soup)
             description = self._extract_description(soup)
 
-            # Initialize metadata dict
             if ctx.metadata is None:
                 ctx.metadata = {}
 
             if description:
                 ctx.metadata["description"] = description
 
-            # Extract rich metadata if enabled
             if self._extract_rich and self._rich_extractor:
                 html_str = ctx.html.decode("utf-8", errors="replace")
                 rich_meta = self._rich_extractor.extract(html_str, ctx.url)
                 ctx.metadata.update(self._rich_extractor.merge_with_fallback(rich_meta, ctx.title))
-                # Update title from rich metadata if better
                 if not ctx.title and ctx.metadata.get("title"):
                     ctx.title = ctx.metadata["title"]
 

--- a/src/docpull/pipeline/steps/save.py
+++ b/src/docpull/pipeline/steps/save.py
@@ -134,13 +134,10 @@ class SaveStep:
             return ctx
 
         try:
-            # Validate output path
             validated_path = self._validate_output_path(output_path)
 
-            # Ensure parent directory exists
             validated_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Write chunked output if requested and available
             if self._emit_chunks and ctx.chunks:
                 stem = validated_path.stem
                 parent = validated_path.parent
@@ -171,7 +168,6 @@ class SaveStep:
                 ctx.persisted_path = first_chunk_path
                 logger.info("Saved %d chunks: %s.*%s", len(ctx.chunks), parent / stem, ext)
             else:
-                # Write full document (use asyncio.to_thread to avoid blocking)
                 await asyncio.to_thread(
                     validated_path.write_text,
                     content,
@@ -209,7 +205,6 @@ class SaveStep:
             return ctx
 
         except ValueError as e:
-            # Path validation error
             ctx.mark_failed(str(e))
             logger.error(f"Path validation failed for {url}: {e}")
 
@@ -225,7 +220,6 @@ class SaveStep:
             raise
 
         except OSError as e:
-            # File system error
             ctx.mark_failed(f"Failed to save: {e}")
             logger.error(f"Failed to save {url} to {output_path}: {e}")
 

--- a/src/docpull/pipeline/steps/save_json.py
+++ b/src/docpull/pipeline/steps/save_json.py
@@ -166,7 +166,6 @@ class JsonSaveStep:
             return self._output_file
 
         try:
-            # Close the documents array and add metadata
             self._temp_file.write("\n  ],\n")
             self._temp_file.write('  "schema_version": 1,\n')
             self._temp_file.write(f'  "generated_at": "{utc_now_iso()}",\n')
@@ -186,7 +185,6 @@ class JsonSaveStep:
             logger.info(f"Saved {self._document_count} documents to {self._output_file}")
 
         except Exception:
-            # Clean up on error
             if self._temp_file:
                 self._temp_file.close()
                 self._temp_file = None


### PR DESCRIPTION
## Summary
- remove comments that only restate adjacent code in conversion, discovery, pipeline, and metadata helpers
- keep comments that document fallback order, compatibility, security, or invariants

## Verification
- uv run --extra dev python -m pre_commit run --all-files