### PR TITLE
chore(release): add guarded release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,16 @@ name: Publish to PyPI
 #   - Workflow name:   publish.yml
 #   - Environment:     pypi
 #
-# Trigger: pushing a `vX.Y.Z` tag. Tag must match pyproject.toml version.
+# Trigger: pushing a `vX.Y.Z` tag, or manual dispatch from `main`.
+# Tag/input version must match pyproject.toml.
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, matching pyproject.toml"
+        required: true
+        type: string
   push:
     tags:
       - "v*.*.*"
@@ -38,6 +45,8 @@ jobs:
 
       - name: Read pyproject.toml version (and verify tag match on tag push)
         id: meta
+        env:
+          REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
           set -e
           PROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
@@ -49,8 +58,17 @@ jobs:
               echo "::error::Tag $TAG does not match pyproject.toml version $PROJECT_VERSION"
               exit 1
             fi
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${GITHUB_REF_NAME}" != "main" ]; then
+              echo "::error::Manual publish must run from main, got ${GITHUB_REF_NAME}"
+              exit 1
+            fi
+            if [ "$REQUESTED_VERSION" != "$PROJECT_VERSION" ]; then
+              echo "::error::Requested version $REQUESTED_VERSION does not match pyproject.toml version $PROJECT_VERSION"
+              exit 1
+            fi
           else
-            echo "::error::Publish workflow only runs from vX.Y.Z tags"
+            echo "::error::Publish workflow only runs from vX.Y.Z tags or manual main dispatch"
             exit 1
           fi
           echo "version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: clean clean-pyc clean-build clean-test help test benchmark benchmark-quick benchmark-parallel benchmark-compare benchmark-matrix benchmark-raindrop license-year metrics metrics-check lint format
+.PHONY: clean clean-pyc clean-build clean-test help test benchmark benchmark-quick benchmark-parallel benchmark-compare benchmark-matrix benchmark-raindrop license-year metrics metrics-check lint format release-pr release-publish release-dispatch
 
 PYTHON ?= .venv/bin/python
+VERSION_ARG := $(if $(VERSION),--version $(VERSION),)
 COPYRIGHT_START_YEAR := 2025
 COPYRIGHT_HOLDER := Raintree Technology
 COPYRIGHT_FILES := LICENSE mcp/LICENSE
@@ -28,6 +29,9 @@ help:
 	@echo "metrics-check - fail if METRICS.md is older than METRICS_MAX_AGE_HOURS"
 	@echo "lint - check style with ruff"
 	@echo "format - format code with ruff"
+	@echo "release-pr - push current release branch and open a protected-main PR"
+	@echo "release-publish - tag merged origin/main and trigger PyPI publish"
+	@echo "release-dispatch - manually dispatch PyPI publish from origin/main"
 
 clean: clean-build clean-pyc clean-test
 
@@ -100,3 +104,12 @@ lint:
 
 format: license-year
 	ruff format .
+
+release-pr:
+	$(PYTHON) scripts/release.py prepare-pr $(VERSION_ARG) --auto-merge
+
+release-publish:
+	$(PYTHON) scripts/release.py publish $(VERSION_ARG) --replace-tag
+
+release-dispatch:
+	$(PYTHON) scripts/release.py dispatch $(VERSION_ARG)

--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ docpull URL --preview-urls    # List URLs without fetching
 - [PyPI](https://pypi.org/project/docpull/)
 - [GitHub](https://github.com/raintree-technology/docpull)
 - [Changelog](https://github.com/raintree-technology/docpull/blob/main/docs/CHANGELOG.md)
+- [Release runbook](https://github.com/raintree-technology/docpull/blob/main/docs/release.md)
 - [Metrics](https://github.com/raintree-technology/docpull/blob/main/METRICS.md) — auto-refreshed daily (PyPI downloads, plugin installs via clone count, traffic)
 
 ## License

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,41 @@
+# Release Runbook
+
+Use the guarded helper instead of hand-typing merge/tag commands.
+
+## Prepare a Release PR
+
+Work on a release branch, commit the release changes, then run:
+
+```bash
+make release-pr VERSION=4.4.0
+```
+
+This pushes the branch, opens a PR into `main`, and enables squash auto-merge.
+It refuses to run directly from `main`.
+
+## Publish After Merge
+
+After the PR merges:
+
+```bash
+git switch main
+git reset --hard origin/main
+make release-publish VERSION=4.4.0
+```
+
+This verifies `origin/main` has the requested `pyproject.toml` version, puts
+`vX.Y.Z` on the merged `origin/main` commit, and pushes the tag to start the
+PyPI workflow. If a tag already points at an old pre-merge commit, the helper
+replaces it only when `--replace-tag` is used through the Makefile target.
+
+## Manual Publish Fallback
+
+If the tag push does not start Actions or the publish job needs to be rerun from
+the merged `main` commit:
+
+```bash
+make release-dispatch VERSION=4.4.0
+```
+
+The workflow refuses manual dispatch from any branch other than `main`, and the
+requested version must match `pyproject.toml`.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Guarded release helper for protected-main PyPI releases."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(*args: str, capture: bool = False, check: bool = True) -> str:
+    proc = subprocess.run(
+        args,
+        cwd=ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+    if check and proc.returncode:
+        if capture and proc.stdout:
+            print(proc.stdout, file=sys.stderr, end="")
+        raise SystemExit(proc.returncode)
+    return proc.stdout.strip() if capture and proc.stdout else ""
+
+
+def git(*args: str, capture: bool = False, check: bool = True) -> str:
+    return run("git", *args, capture=capture, check=check)
+
+
+def gh(*args: str, capture: bool = False, check: bool = True) -> str:
+    return run("gh", *args, capture=capture, check=check)
+
+
+def project_version_from_text(text: str) -> str:
+    return tomllib.loads(text)["project"]["version"]
+
+
+def local_project_version() -> str:
+    return project_version_from_text((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def ref_project_version(ref: str) -> str:
+    return project_version_from_text(git("show", f"{ref}:pyproject.toml", capture=True))
+
+
+def ref_sha(ref: str) -> str:
+    return git("rev-parse", "--verify", ref, capture=True)
+
+
+def current_branch() -> str:
+    return git("branch", "--show-current", capture=True)
+
+
+def ensure_clean() -> None:
+    dirty = git("status", "--porcelain", capture=True)
+    if dirty:
+        raise SystemExit(f"Working tree is not clean:\n{dirty}")
+
+
+def fetch() -> None:
+    git("fetch", "origin", "--prune")
+
+
+def remote_tag_sha(tag: str) -> str | None:
+    output = git("ls-remote", "--tags", "origin", f"refs/tags/{tag}*", capture=True)
+    if not output:
+        return None
+    exact_ref = f"refs/tags/{tag}"
+    peeled_ref = f"{exact_ref}^{{}}"
+    refs = {}
+    for line in output.splitlines():
+        sha, ref = line.split(maxsplit=1)
+        refs[ref] = sha
+    return refs.get(peeled_ref) or refs.get(exact_ref)
+
+
+def delete_local_tag(tag: str) -> None:
+    git("tag", "-d", tag, check=False)
+
+
+def prepare_pr(args: argparse.Namespace) -> None:
+    ensure_clean()
+    version = args.version or local_project_version()
+    branch = args.branch or f"release/{version}-pr"
+    title = args.title or f"chore(release): prepare {version}"
+    body = args.body or (
+        f"Prepares docpull {version}. After this PR merges, run "
+        f"`make release-publish VERSION={version}` from an up-to-date checkout."
+    )
+
+    fetch()
+    if current_branch() == "main":
+        raise SystemExit("Do not prepare a release directly on main. Create a release branch first.")
+    if local_project_version() != version:
+        raise SystemExit(f"pyproject.toml is {local_project_version()}, not requested version {version}.")
+
+    git("push", "-u", "origin", f"HEAD:{branch}")
+    create = gh(
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        branch,
+        "--title",
+        title,
+        "--body",
+        body,
+        capture=True,
+        check=False,
+    )
+    if create:
+        print(create)
+    if args.auto_merge:
+        gh("pr", "merge", "--squash", "--auto")
+
+    print(f"Release PR branch is {branch}. Do not tag {version} until the PR is merged.")
+
+
+def publish(args: argparse.Namespace) -> None:
+    ensure_clean()
+    version = args.version or local_project_version()
+    tag = f"v{version}"
+
+    fetch()
+    main_sha = ref_sha("origin/main")
+    main_version = ref_project_version("origin/main")
+    if main_version != version:
+        raise SystemExit(f"origin/main has pyproject version {main_version}, not {version}.")
+
+    existing = remote_tag_sha(tag)
+    if existing and existing != main_sha:
+        if not args.replace_tag:
+            raise SystemExit(
+                f"Remote {tag} points at {existing[:12]}, but origin/main is {main_sha[:12]}.\n"
+                f"Re-run with --replace-tag after confirming {version} was not already published."
+            )
+        delete_local_tag(tag)
+        git("push", "origin", f":refs/tags/{tag}")
+        existing = None
+
+    if existing == main_sha:
+        print(f"{tag} already points at origin/main {main_sha[:12]}.")
+    else:
+        delete_local_tag(tag)
+        git("tag", tag, main_sha)
+        git("push", "origin", tag)
+        print(f"Pushed {tag} at origin/main {main_sha[:12]}.")
+
+    print("Watch the publish run with:")
+    print("  gh run list --workflow publish.yml --branch", tag, "--limit 5")
+    print("  gh run watch <run-id>")
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    ensure_clean()
+    version = args.version or local_project_version()
+    fetch()
+    main_version = ref_project_version("origin/main")
+    if main_version != version:
+        raise SystemExit(f"origin/main has pyproject version {main_version}, not {version}.")
+    gh("workflow", "run", "publish.yml", "--ref", "main", "-f", f"version={version}")
+    print("Dispatched Publish to PyPI from main.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    pr = sub.add_parser("prepare-pr", help="Push current release branch and open a main PR.")
+    pr.add_argument("--version", help="Expected version; defaults to pyproject.toml")
+    pr.add_argument("--branch", help="Remote PR branch; defaults to release/<version>-pr")
+    pr.add_argument("--title", help="PR title")
+    pr.add_argument("--body", help="PR body")
+    pr.add_argument("--auto-merge", action="store_true", help="Enable squash auto-merge")
+    pr.set_defaults(func=prepare_pr)
+
+    pub = sub.add_parser("publish", help="Tag merged origin/main and trigger tag-based PyPI publish.")
+    pub.add_argument("--version", help="Expected version; defaults to pyproject.toml")
+    pub.add_argument("--replace-tag", action="store_true", help="Replace a remote tag that points elsewhere")
+    pub.set_defaults(func=publish)
+
+    disp = sub.add_parser("dispatch", help="Manually dispatch PyPI publish from origin/main.")
+    disp.add_argument("--version", help="Expected version; defaults to pyproject.toml")
+    disp.set_defaults(func=dispatch)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -35,10 +35,15 @@ def test_workflows_do_not_use_latest_container_tags() -> None:
     assert offenders == []
 
 
-def test_publish_workflow_is_tag_only() -> None:
+def test_publish_workflow_accepts_only_tags_or_guarded_manual_dispatch() -> None:
     publish = (WORKFLOW_DIR / "publish.yml").read_text()
-    assert "workflow_dispatch" not in publish
     assert '"v*.*.*"' in publish
+    assert "workflow_dispatch:" in publish
+    assert "version:" in publish
+    assert 'required: true' in publish
+    assert 'elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then' in publish
+    assert 'if [ "${GITHUB_REF_NAME}" != "main" ]; then' in publish
+    assert 'if [ "$REQUESTED_VERSION" != "$PROJECT_VERSION" ]; then' in publish
 
 
 def test_plugin_readme_cache_path_matches_mcp_default() -> None:


### PR DESCRIPTION
Adds guarded release helper, Makefile targets, release runbook, and manual PyPI publish dispatch from main.