### PR TITLE
chore(release): prepare 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docpull
 
-**Public web to agent-ready Markdown. Fast, local, browser-free.**
+**Turn public documentation sites into local Markdown, NDJSON, and agent-ready context packs. No browser required.**
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://badge.fury.io/py/docpull.svg)](https://badge.fury.io/py/docpull)
@@ -8,395 +8,218 @@
 [![GitHub stars](https://img.shields.io/github/stars/raintree-technology/docpull?style=social)](https://github.com/raintree-technology/docpull/stargazers)
 [![License: MIT](https://img.shields.io/github/license/raintree-technology/docpull)](https://github.com/raintree-technology/docpull/blob/main/LICENSE)
 
-<p align="center">
-  <a href="https://docpull.raintree.technology">
-    <img src="https://pub-e85a1abca36f4fd8b4300a6ec2d6f45f.r2.dev/marketing/docpull/1768954147343-iaiziy-docpull-terminal-hero.gif" alt="docpull demo" width="600">
-  </a>
-</p>
+docpull is a Python CLI, SDK, and MCP server that fetches public static or
+server-rendered web pages and converts them into clean, auditable local
+artifacts for LLMs, retrieval-augmented generation (RAG), offline research, and
+agent workflows.
 
-docpull is a Python CLI, SDK, and MCP server for pulling public static and
-server-rendered web pages into clean Markdown, NDJSON, OKF bundles, SQLite, or
-local archives. Web-source extraction is the core workflow; docs are one
-high-value lane alongside blogs, API references, vendor pages, OpenAPI specs,
-and other server-rendered web content. It uses async HTTP instead
-of Playwright, preserves source metadata, and is built for agent-selected URLs
-with SSRF, XXE, DNS-rebinding, and CRLF-injection protections enabled by
-default.
+It works best on documentation sites, blogs, API references, OpenAPI specs,
+vendor pages, and other public pages where the useful content is available in
+HTML or embedded page data.
 
-Use docpull when you need to:
-
-- Load public web pages, docs, API references, or blogs into an LLM context.
-- Build inspectable source corpora for RAG/search pipelines.
-- Give a coding agent a local MCP tool for fetching, caching, grepping, and
-  reading docs.
-- Mirror public web content for offline work while keeping source attribution.
-
-docpull intentionally does not render JavaScript. For JS-only apps, browser
-automation, paid extraction APIs, or general web crawling, see
-[`docs/scraping-boundary.md`](docs/scraping-boundary.md) and
-[`docs/alternatives.md`](docs/alternatives.md).
-
-## Try it in 60 seconds
-
-```bash
-pip install docpull
-docpull https://docs.python.org/3/library/asyncio.html --single
-docpull https://docs.python.org/3/library/asyncio.html --profile llm --stream | jq .
-```
+docpull is not a browser and does not render JavaScript. JS-only pages are
+skipped with a clear reason. See [Scraping Boundary](docs/scraping-boundary.md)
+and [Alternatives](docs/alternatives.md) for the full boundary.
 
 ## Install
 
 ```bash
 pip install docpull
-
-# Optional extras
-pip install 'docpull[llm]'           # tiktoken for token-accurate chunking
-pip install 'docpull[trafilatura]'   # alternative extractor for noisy pages
-pip install 'docpull[mcp]'           # run as an MCP server for AI agents
-pip install 'docpull[parallel]'      # Parallel API context packs
-pip install 'docpull[observability]' # Raindrop benchmark tracing
-pip install 'docpull[all]'           # everything above
 ```
 
-## Quick start
+Install optional extras as needed:
 
 ```bash
-# Scrape a page graph and save Markdown
-docpull https://docs.example.com
+pip install 'docpull[llm]'           # tiktoken for token-accurate chunking
+pip install 'docpull[trafilatura]'   # alternative extractor for noisy pages
+pip install 'docpull[mcp]'           # stdio MCP server
+pip install 'docpull[parallel]'      # Parallel context packs
+pip install 'docpull[observability]' # Raindrop benchmark tracing
+pip install 'docpull[all]'           # all optional extras
+```
 
-# Scrape one page, no crawl — the fast path for agents
-docpull https://docs.example.com/guide --single
+## 30-Second Usage
 
-# LLM-ready NDJSON with 4k-token chunks streamed to stdout
+```bash
+docpull https://docs.python.org/3/library/asyncio.html --single -o ./asyncio-docs
+```
+
+Example output:
+
+```text
+asyncio-docs/
+  index.md
+  corpus.manifest.json
+```
+
+Markdown includes source metadata and readable page content:
+
+```markdown
+---
+title: "asyncio - Asynchronous I/O"
+source: https://docs.python.org/3/library/asyncio.html
+source_type: "sphinx"
+---
+
+# asyncio - Asynchronous I/O
+
+asyncio is a library to write concurrent code using the async/await syntax.
+```
+
+Stream chunked NDJSON for agents and RAG:
+
+```bash
+docpull https://docs.python.org/3/library/asyncio.html \
+  --single \
+  --profile llm \
+  --stream | jq .
+```
+
+Each line is a JSON document:
+
+```json
+{"schema_version":1,"document_id":"doc_...","chunk_id":"chunk_...","url":"https://docs.python.org/3/library/asyncio.html","title":"asyncio - Asynchronous I/O","content":"asyncio is a library to write concurrent code...","source_type":"sphinx","chunk_index":0,"token_count":842}
+```
+
+## Common Workflows
+
+```bash
+# Crawl a site and write Markdown files
+docpull https://docs.example.com -o ./docs-example
+
+# Stream LLM-ready NDJSON chunks from a site
 docpull https://docs.example.com --profile llm --stream | jq .
 
-# Open Knowledge Format bundle for agent/wiki interoperability
-docpull https://example.com --format okf -o ./site-okf
+# Write SQLite with an FTS5 search index
+docpull https://docs.example.com --format sqlite -o ./docs-db
 
-# SEC filing evidence pack with citation anchors
-docpull evidence-pack filings.ndjson \
-  --profile sec-filing \
-  --rules docs/examples/vendor-dependency-rules.yml \
-  --sec-user-agent "YourOrg your-email@example.com" \
-  --output-dir packs/dla-vendors
-
-# Mirror scraped content for offline use
-docpull https://docs.example.com --profile mirror --cache
+# Build an Open Knowledge Format (OKF) bundle for portable source packs
+docpull https://example.com --profile okf -o ./site-okf
 ```
 
-## Project traction
+More examples live in [CLI Recipes](docs/examples/README.md).
 
-<a href="https://pepy.tech/project/docpull">
-  <img alt="Cumulative PyPI download history chart for docpull" src="docs/cumulative-downloads-history.svg" />
-</a>
+Use docpull when you need to:
 
-<a href="https://star-history.com/#raintree-technology/docpull&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=raintree-technology/docpull&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=raintree-technology/docpull&type=Date" />
-    <img alt="Star history chart for raintree-technology/docpull" src="https://api.star-history.com/svg?repos=raintree-technology/docpull&type=Date" />
-  </picture>
-</a>
+- Convert public docs, blogs, API references, vendor pages, and OpenAPI specs
+  into Markdown or chunked NDJSON for LLM and RAG pipelines.
+- Give an agent a local tool for fetching, caching, grepping, and reading web
+  sources.
+- Build repeatable context packs with stable IDs, hashes, manifests, and source
+  metadata.
+- Mirror public web content for offline work while preserving attribution.
 
-## Framework-aware extraction
+## Why docpull?
 
-docpull inspects each page before running the generic extractor and can pull
-content directly from framework data feeds:
+docpull is designed for agent and RAG workflows, not just downloading pages.
 
-| Framework | Strategy |
-|-----------|----------|
-| Next.js   | Parses `__NEXT_DATA__` JSON |
-| Mintlify  | `__NEXT_DATA__` with Mintlify tagging |
-| OpenAPI   | Renders `openapi.json` / `swagger.json` into Markdown |
-| Docusaurus| Extracts static article regions and tags framework metadata |
-| Sphinx    | Extracts static body/document regions and tags framework metadata |
-| MkDocs / Material | Extracts static content regions and tags framework metadata |
-| VitePress / VuePress | Extracts static doc regions and tags framework metadata |
-| Astro Starlight | Extracts static markdown content regions and tags framework metadata |
-| GitBook / ReadMe.io | Extracts static article/content regions and tags framework metadata |
-| Redoc / Scalar | Extracts static API reference regions; OpenAPI JSON is still preferred when available |
+| Need | docpull gives you |
+| --- | --- |
+| Clean Markdown | Article-focused extraction with source metadata |
+| LLM chunks | NDJSON streaming and optional token-aware chunking |
+| Repeatability | Stable document IDs, chunk IDs, hashes, and manifests |
+| Offline work | Cached archives and mirrored source artifacts |
+| Agent access | Local CLI, Python SDK, and stdio MCP server |
+| Safer fetching | HTTPS defaults, robots.txt compliance, SSRF protections, and redirect guards |
 
-JS-only SPAs with no server-rendered content are detected and skipped with a
-clear reason (or, with `--strict-js-required`, reported as an error so agents
-can route elsewhere).
+## Supported Sources
 
-## Agent-friendly features
+docpull uses async HTTP instead of browser automation and includes special
+handling for common documentation and API surfaces.
 
-- **`--single`** — fetch a single URL without discovery. Designed for tool loops.
-- **`--stream`** — NDJSON one-record-per-line, flushed on every page, pipeable.
-- **`--max-tokens-per-file N`** — split each page into token-bounded chunks on
-  heading boundaries (exact counts with tiktoken, estimate without).
-- **`--emit-chunks`** — write one file or record per chunk instead of per page.
-- **`--strict-js-required`** — hard-fail on JS-only pages instead of silently
-  skipping.
-- **`--extractor trafilatura`** — swap in [trafilatura](https://trafilatura.readthedocs.io/)
-  for sites where the default heuristics struggle.
+| Source shape | Support |
+| --- | --- |
+| Static HTML / SSR docs | Extracts article or document regions |
+| Next.js / Mintlify | Parses static HTML and `__NEXT_DATA__` when available |
+| OpenAPI / Swagger | Renders specs into Markdown |
+| Docusaurus / Sphinx / MkDocs | Extracts static article or document regions |
+| VitePress / VuePress / Astro Starlight | Extracts static docs content |
+| GitBook / ReadMe.io | Extracts available article or content regions |
+| Redoc / Scalar | Extracts static API reference regions |
+| JS-only apps | Skipped unless useful content is present in HTML or embedded data |
 
-## Python API
+Use `--strict-js-required` when an agent should treat JS-only pages as hard
+errors instead of normal skips.
 
-Scraper-facing API:
+## Output Formats
 
-```python
-import asyncio
-from docpull import scrape_one, Scraper
+| Output | Use it for |
+| --- | --- |
+| Markdown | Local readable source snapshots with YAML frontmatter |
+| NDJSON | Streamed records or chunked records for agents and RAG |
+| SQLite | Local retrieval with an FTS5 index |
+| OKF | Portable Open Knowledge Format bundles with indexes and manifests |
+| Archive / mirror | Cached offline source snapshots |
 
-async def main():
-    page = await scrape_one("https://docs.python.org/3/library/asyncio.html")
-    print(page.title, page.source_type)
-    print(page.text[:500])
+Every file-backed run writes `corpus.manifest.json` with stable document IDs,
+chunk IDs, hashes, output paths, and chunk counts. See
+[Corpus Manifest](docs/corpus-manifest.md).
 
-    scraper = Scraper()
-    run = await scraper.scrape_site(
-        "https://docs.example.com",
-        output_format="ndjson",
-        max_pages=100,
-    )
-    print(run.stats.pages_fetched, run.manifest_path)
+## Profiles
 
-asyncio.run(main())
+```bash
+docpull https://site.com --profile rag        # Default. Dedup + metadata.
+docpull https://site.com --profile llm        # NDJSON chunks for agents/RAG.
+docpull https://site.com --profile okf        # Portable Open Knowledge Format bundle.
+docpull https://site.com --profile mirror     # Cached archive.
+docpull https://site.com --profile quick      # Small sampling crawl.
+docpull https://site.com --profile sec-filing # EDGAR-friendly evidence chunks.
 ```
 
-Core fetcher API:
+Run `docpull --help` for the full option list.
+
+## When Not to Use docpull
+
+docpull intentionally does not use a browser. It is not the right tool for:
+
+- JS-only pages that require client-side rendering.
+- Authenticated dashboards or private apps.
+- Pages behind CAPTCHA or bot challenges.
+- Workflows that require clicking, scrolling, or browser state.
+
+For those cases, use browser automation, such as Playwright, then pass the
+rendered HTML or exported content into your pipeline.
+
+## How It Compares
+
+| Tool type | Best for | Tradeoff |
+| --- | --- | --- |
+| `wget` / site mirroring | Downloading raw files | Not agent/RAG-oriented |
+| Browser automation | JS-heavy pages and interactions | Slower, heavier, more stateful |
+| Hosted extraction APIs | Managed extraction at scale | External dependency and cost |
+| docpull | Local public-doc extraction and context packs | No JavaScript rendering |
+
+## Python SDK
 
 ```python
 from docpull import fetch_one
 
 ctx = fetch_one("https://docs.python.org/3/library/asyncio.html")
-print(ctx.title, ctx.source_type)
+print(ctx.title)
 print(ctx.markdown[:500])
 ```
 
-Async streaming:
-
 ```python
 import asyncio
-from docpull import Fetcher, DocpullConfig, ProfileName, EventType
+from docpull import Fetcher, DocpullConfig, EventType, ProfileName
 
 async def main():
-    cfg = DocpullConfig(
-        url="https://docs.example.com",
-        profile=ProfileName.LLM,  # chunked NDJSON output
-    )
+    cfg = DocpullConfig(url="https://docs.example.com", profile=ProfileName.LLM)
     async with Fetcher(cfg) as fetcher:
         async for event in fetcher.run():
             if event.type == EventType.FETCH_PROGRESS:
                 print(f"{event.current}/{event.total}: {event.url}")
-        print(f"Done: {fetcher.stats.pages_fetched} pages")
 
 asyncio.run(main())
 ```
 
-Single-page from an agent tool:
+## MCP Server
 
-```python
-from docpull import Fetcher, DocpullConfig
-
-async def tool_call(url: str) -> str:
-    async with Fetcher(DocpullConfig(url=url)) as f:
-        ctx = await f.fetch_one(url, save=False)
-        return ctx.markdown or ctx.error or ""
-```
-
-## Profiles
-
-```bash
-docpull https://site.com --profile rag      # Default. Dedup, rich metadata.
-docpull https://site.com --profile llm      # NDJSON + chunks + metadata; JS-only pages skip unless --strict-js-required is passed.
-docpull https://site.com --profile okf      # OKF bundle with generated index.md files.
-docpull https://site.com --profile sec-filing # EDGAR-friendly NDJSON chunks, trafilatura, Inline XBRL cleanup.
-docpull https://site.com --profile mirror   # Full archive, polite, cached, hierarchical paths.
-docpull https://site.com --profile quick    # Sampling: 50 pages, depth 2.
-```
-
-## SEC filing evidence packs
-
-`docpull evidence-pack` turns an NDJSON list of filings into a source pack for
-government/vendor-dependency research. Each input row needs a filing URL under
-`primary_document_url` or `url`; filing fields such as `cik`,
-`accession_number`, `form`, `filing_date`, and `issuer_name` are carried into
-the emitted records.
-
-Use `docs/examples/vendor-dependency-rules.yml` as a starting rule profile for
-government customer, customer concentration, segment revenue, and related-party
-signals. Rules can use literal strings or regex entries with optional
-confidence values.
-
-The pack writes `evidence.pack.json`, `documents.ndjson`, `evidence.ndjson`,
-`diagnostics.ndjson`, `sources.md`, `corpus.manifest.json`,
-`EVIDENCE_CONTEXT.md`, and `AGENT_CONTEXT.md`. Evidence hits include source URL,
-chunk id, section heading when available, quote, surrounding context, source
-document hash, confidence, and extraction method. Diagnostics flag no readable
-content, high XBRL noise, degraded tables, missing evidence categories, and
-source hash changes since the last run.
-
-## Parallel context packs
-
-`docpull[parallel]` adds an optional source-discovery and research layer on top
-of Parallel web intelligence APIs. Use the core crawler when you already know
-the target URL. Use Parallel packs when an agent needs current web sources found,
-extracted, researched, organized, and loaded as durable local context.
-
-Parallel handles live Search, Extract, Task, Entity Search, FindAll, TaskGroup,
-and Monitor calls. docpull turns those results into local, inspectable packs
-with Markdown, NDJSON, manifests, hashes, source indexes, workflow metadata, and
-an `AGENT_CONTEXT.md` load plan so agents do not need to reverse-engineer raw API
-responses before using the pack.
-
-Live calls use your own Parallel API key. docpull never proxies requests through
-a shared account or writes the key into pack artifacts. For normal PyPI installs,
-`docpull parallel init` stores the key in a local secrets file with restricted
-permissions so it works across shells and agent sessions. Pack artifacts can
-still contain source content, workflow inputs/outputs, selected URLs, and
-metadata, so treat them as research data.
-
-```bash
-pip install 'docpull[parallel]'
-
-# Recommended local setup. Prompts securely and writes ~/.config/docpull/secrets.env.
-docpull parallel init
-docpull parallel auth --json
-
-# Optional project-local setup for agent worktrees. Writes .env.local and
-# adds it to .gitignore.
-docpull parallel init --project
-
-# CI can still use a normal environment secret instead.
-export PARALLEL_API_KEY="<your-parallel-api-key>"
-
-docpull parallel context-pack "Compare AI web-search APIs for agents" \
-  --query "AI web search API" \
-  --query "agent web extraction API" \
-  --include-domain parallel.ai \
-  --exclude-domain onparallel.com \
-  --output-dir ./packs/ai-web-search \
-  --mode advanced \
-  --extract-limit 8 \
-  --max-estimated-cost 0.05 \
-  --task-brief
-```
-
-`docpull parallel auth` checks local SDK/key presence without printing the key
-value and reports the key source (`env`, `project_env`, `user_config`, or
-`missing`). It does not make a live Parallel call or prove the key is valid. Use
-`--json` when an agent or CI job needs machine-readable configuration status.
-
-## Optional live providers
-
-Parallel, Tavily, and Exa are equal optional live providers for benchmark and
-provider context-pack workflows. You can configure zero, one, two, or all three
-API keys. docpull looks for keys in this order: environment variables, project
-`.env.local`, then `~/.config/docpull/secrets.env`. Missing providers are skipped
-instead of failing provider-neutral runs.
-
-```bash
-docpull providers auth --json
-docpull providers init parallel
-docpull providers init tavily
-docpull providers init exa
-
-docpull providers context-pack "Compare AI web-search APIs for agents" \
-  --provider auto \
-  --query "AI web search API" \
-  --include-domain docs.parallel.ai \
-  --output-dir ./packs/provider-comparison
-```
-
-Use `--provider all` to request all three and record skipped-provider metadata
-for keys or optional SDKs that are not configured. Use repeated `--provider`
-values to run a specific subset.
-
-A Parallel pack contains:
-
-- `AGENT_CONTEXT.md` — agent load plan with source order, pack signals, warnings, errors, and artifact map.
-- `documents.ndjson` — chunked records for agents and RAG pipelines.
-- `corpus.manifest.json` — stable docpull record manifest.
-- `parallel.pack.json` — Parallel workflow metadata, selected URLs, errors, IDs, and usage.
-- `sources.md` and `sources/*.md` — human-readable sources and extracted Markdown.
-- `brief.md` when `--task-brief` is enabled.
-
-That makes the Parallel layer more than a pass-through wrapper: Parallel finds
-and enriches live web sources, while docpull normalizes them into a repeatable
-context pack that can be scored, diffed, audited, and loaded offline.
-
-For planning without spending credits, use `--dry-run`. For repeatable packs,
-use `--include-domain`, `--exclude-domain`, `--after-date`, and `--max-search-results`
-to pin the source policy that appears later in `parallel.pack.json`.
-Use `--fetch-max-age-seconds`, `--fetch-timeout-seconds`,
-`--disable-cache-fallback`, `--excerpt-chars-per-result`, and `--location`
-when you need Parallel's freshness, excerpt-size, and geo controls.
-
-Offline fixtures are supported for demos and tests without a Parallel account:
-
-```bash
-docpull parallel demo --output-dir ./packs/demo
-```
-
-When working from the source checkout, the same fixture can also be imported
-directly with `docpull parallel import ./docs/examples/parallel-search-extract.json`.
-
-The core workflow is Search + Extract + optional Task. Broader pack workflows
-cover Search-only snapshots, docs discovery plans, Extract-known-URL packs,
-core-fetch-with-Parallel-fallback packs, diff briefs, Task lifecycle snapshots,
-Entity Search, FindAll lifecycle actions, TaskGroup batches, Monitor
-metadata/events, API specs, and local source scoring.
-See [docs/parallel.md](docs/parallel.md) for the Parallel product cross-reference
-and the boundary between docpull, Parallel MCP, and planned workflows.
-
-Additional Parallel-backed artifact commands:
-
-```bash
-# Readiness and API-key setup checks.
-docpull parallel auth
-docpull parallel init
-docpull parallel init --project
-
-# Search + Extract + optional Task brief.
-docpull parallel context-pack "Compare AI web-search APIs for agents" \
-  --query "AI web search API" \
-  --include-domain parallel.ai \
-  --dry-run
-
-# Search-only, docs-discovery, known-URL extract, fallback, and structured Task packs.
-docpull parallel search-pack "Parallel Search API docs" --query "Parallel Search API" --dry-run
-docpull parallel discover-docs "Find Parallel API docs" \
-  --query "Parallel Search API docs" \
-  --include-domain docs.parallel.ai \
-  --dry-run
-docpull parallel extract-pack https://docs.parallel.ai/api-reference/search/search --dry-run
-docpull parallel fallback-pack https://docs.parallel.ai/api-reference/search/search --dry-run
-docpull parallel task-pack "Research Parallel Search API" \
-  --source-include-domain docs.parallel.ai \
-  --output-schema-json '{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}' \
-  --dry-run
-
-# Entity dossiers, FindAll lifecycle, batch enrichment, monitors, and API specs.
-docpull parallel entity-pack "AI developer infrastructure companies" --entity-type companies
-docpull parallel findall-pack "AI developer infrastructure companies" --generator preview --dry-run
-docpull parallel findall-ingest-pack "Find companies with public API docs"
-docpull parallel findall-result-pack findall_123 --output-dir ./packs/findall-result
-docpull parallel taskgroup-pack ./companies.json --prompt-template "Research {company}" --dry-run
-docpull parallel taskgroup-pack ./companies.json --prompt-template "Research {company}" --wait
-docpull parallel monitor-pack create "New vendor pricing changes" --dry-run
-docpull parallel monitor-pack create --type snapshot --task-run-id run_123 --dry-run
-docpull parallel monitor-pack list --status active --output-dir ./packs/monitors
-docpull parallel monitor-pack events monitor_123 --cursor next_cursor --output-dir ./packs/events
-docpull parallel api-pack https://docs.parallel.ai/public-openapi.json --output-dir ./packs/parallel-openapi
-docpull parallel run ./docs/examples/parallel-llms-api-pack.yaml --dry-run
-docpull parallel run ./docs/examples/parallel-openapi-api-pack.yaml --dry-run
-docpull pack score ./packs/parallel-openapi
-docpull pack sources ./packs/parallel-openapi --require-domain docs.parallel.ai
-docpull pack diff ./packs/old ./packs/new --markdown ./packs/changes.md
-docpull parallel diff-brief ./packs/old ./packs/new --dry-run
-```
-
-## MCP server
-
-docpull ships an MCP (Model Context Protocol) server so AI agents can call it
-directly over stdio:
+docpull can run as a stdio MCP server for agent clients:
 
 ```bash
 pip install 'docpull[mcp]'
-docpull mcp  # starts the stdio server
+docpull mcp
 ```
 
 Claude Code:
@@ -405,7 +228,7 @@ Claude Code:
 claude mcp add --transport stdio docpull -- docpull mcp
 ```
 
-Cursor (`.cursor/mcp.json` in a project, or `~/.cursor/mcp.json` globally):
+Cursor and Claude Desktop use the same `mcpServers` shape:
 
 ```json
 {
@@ -419,302 +242,56 @@ Cursor (`.cursor/mcp.json` in a project, or `~/.cursor/mcp.json` globally):
 }
 ```
 
-Claude Desktop uses the same `mcpServers` shape in
-`claude_desktop_config.json`.
+The supported MCP path is the Python stdio server started by `docpull mcp`.
+The repository's `mcp/` directory is an internal TypeScript/Bun lab and is not
+part of the package release contract.
 
-Or, if you use Claude Code, install the plugin instead — it bundles the MCP
-server, five slash commands (`/docs-add`, `/docs-search`, `/docs-list`,
-`/docs-refresh`, `/docs-remove`), and a meta-skill that teaches Claude
-when to reach for docpull automatically:
+## Advanced Workflows
 
-```bash
-# 1. Install docpull with the MCP extra (required for the plugin)
-pip install 'docpull[mcp]'
-```
+- `docpull[parallel]` can discover, extract, enrich, score, diff, and archive
+  live web sources with your own Parallel API key. See
+  [Parallel Integration](docs/parallel.md).
+- Optional provider workflows can use Parallel, Tavily, and Exa when configured.
+  See [CLI Recipes](docs/examples/README.md#parallel-context-pack).
+- SEC filing evidence packs use rule profiles such as
+  [vendor-dependency-rules.yml](docs/examples/vendor-dependency-rules.yml).
 
-```
-# 2. Then in Claude Code:
-/plugin marketplace add raintree-technology/docpull
-/plugin install docpull@docpull
-```
+## Security Defaults
 
-See [plugin/README.md](plugin/README.md) for details.
-
-Tools exposed (12 total — read tools advertise `readOnlyHint` so hosts that auto-approve safe tools won't prompt):
-
-Read:
-- `fetch_url(url, max_tokens?)` — one-shot fetch, no crawl. HTTPS-only, SSRF-validated.
-- `list_sources(category?)` — show available aliases (react, nextjs, parallel, fastapi, …)
-- `list_indexed()` — what has been fetched locally, with last-fetched age
-- `grep_docs(pattern, library?, limit?, context?)` — regex search across fetched Markdown (length-capped + wall-clock budgeted to mitigate ReDoS)
-- `read_doc(library, path, line_start?, line_end?)` — read a specific cached file, optionally line-sliced
-- `pack_score(pack_dir, required_domains?)` — score a local context pack for agent readiness.
-- `pack_diff(old_pack_dir, new_pack_dir)` — compare pack URL sets and content hashes.
-
-Write:
-- `ensure_docs(source, force?, profile?)` — fetch a named library (cached 7 days). Forwards progress to clients that supply a `progressToken`.
-- `parallel_context_pack(...)` — build or dry-run a Parallel Search + Extract pack without shelling out.
-- `parallel_api_pack(source, kind?, output_dir?)` — build a pack from `llms.txt` or OpenAPI.
-- `add_source(name, url, description?, category?, max_pages?, force?)` — register a user alias (HTTPS-only, atomic write to `sources.yaml`).
-- `remove_source(name, delete_cache?)` — drop a user alias and (optionally) its cached Markdown.
-
-All schema-backed tools return `structuredContent` validated against an
-`outputSchema` for clients that prefer typed output. `fetch_url` intentionally
-returns Markdown text directly.
-
-User-defined sources live in `~/.config/docpull-mcp/sources.yaml`:
-
-```yaml
-sources:
-  mydocs:
-    url: https://docs.example.com
-    description: My internal docs
-    category: internal
-    maxPages: 200
-```
-
-### Supported MCP path
-
-The supported MCP server is the Python stdio server started by `docpull mcp`.
-That is the only MCP path covered by the `docpull` package release contract and
-the one agents, plugin users, Claude Code, Cursor, and Claude Desktop should
-use.
-
-This repository also contains an `mcp/` directory with an internal TypeScript +
-Bun lab for PostgreSQL/pgvector semantic search. It is not shipped by the Python
-package, is not documented as a user install path, and should be ignored unless
-you are explicitly developing that lab.
-
-## Output
-
-Markdown files with YAML frontmatter:
-
-```markdown
----
-title: "Getting Started"
-source: https://docs.example.com/guide
-source_type: "nextjs"
----
-
-# Getting Started
-…
-```
-
-NDJSON (one record per page or chunk):
-
-```json
-{"document_id": "doc_...", "chunk_id": "chunk_...", "url": "...", "title": "...", "content": "...", "hash": "...", "token_count": 842, "chunk_index": 0}
-```
-
-Open Knowledge Format:
-
-```bash
-docpull https://example.com --format okf -o ./site-okf
-
-# Equivalent profile form
-docpull https://example.com --profile okf -o ./site-okf
-```
-
-A generated OKF bundle has a normal Markdown tree:
-
-```text
-site-okf/
-  index.md
-  corpus.manifest.json
-  _root.md
-  docs/
-    index.md
-    getting-started.md
-```
-
-OKF output is an opt-in Markdown bundle. Scraped pages are written as concept
-documents with OKF frontmatter (`type`, `title`, `description`, `resource`,
-`tags`, `timestamp` when source metadata exists) and docpull keeps `source` as a
-compatibility extension. Generated `index.md` files are reserved for directory
-listings, so URL landing pages use safe concept filenames such as `_root.md` or
-`_page.md` instead of occupying `index.md`. The root `index.md` declares
-`okf_version: "0.1"`; nested indexes stay plain listing files.
-
-Because OKF treats every non-reserved `.md` file in the tree as a concept, write
-OKF output to a clean or dedicated directory rather than mixing it with unrelated
-Markdown files.
-
-Every output format also writes `corpus.manifest.json` next to the generated
-documents. The manifest records the run identity, output format, stable
-`document_id` / `chunk_id` values, content hashes, file-backed relative output
-paths (or the stdout marker for streamed NDJSON), and chunk counts so
-regenerated corpora can be diffed and cited by agents. See
-[`docs/corpus-manifest.md`](docs/corpus-manifest.md) for the schema and
-stability contract.
-
-SQLite output includes an FTS5 index for local retrieval:
-
-```python
-from pathlib import Path
-from docpull import search_sqlite_documents
-
-hits = search_sqlite_documents(Path("docs/documents.db"), "rate limit")
-for hit in hits:
-    print(hit.url, hit.snippet)
-```
-
-## Security
-
-- HTTPS-only, mandatory robots.txt compliance
-- SSRF protection: blocks private/internal network IPs, DNS rebinding via
-  connect-time address pinning
-- XXE protection via `defusedxml` on sitemaps
-- Path traversal and CRLF header injection guards
-- Auth headers stripped on cross-origin redirects
+- HTTPS-only fetching with robots.txt compliance.
+- SSRF protections, private network blocking, DNS rebinding protection, and
+  connect-time address pinning.
+- XXE protection for sitemaps.
+- Path traversal and CRLF header injection guards.
+- Auth headers stripped on cross-origin redirects.
 
 When running with `--proxy`, DNS pinning is delegated to the proxy. Pass
-`--require-pinned-dns` to refuse this configuration and keep the connector-
-level SSRF guarantees in effect.
-HTTP and HTTPS proxies work with the base install; SOCKS proxies require
-`pip install "docpull[proxy]"`.
-
-## Options
-
-Run `docpull --help` for the full list. Highlights:
-
-```
-Core:
-  --profile {rag,mirror,quick,llm,okf,sec-filing}
-  --single                Fetch one URL (no crawl)
-  --format {markdown,json,ndjson,sqlite,okf}
-  --stream                Stream NDJSON to stdout
-
-LLM / chunking:
-  --max-tokens-per-file N
-  --tokenizer NAME        tiktoken encoding (default cl100k_base)
-  --emit-chunks           One file/record per chunk
-
-Content extraction:
-  --extractor {default,trafilatura}
-  --no-special-cases      Disable framework extractors
-  --strict-js-required    Error on JS-only pages
-
-Cache:
-  --cache                 Enable incremental updates
-  --cache-dir DIR
-  --cache-ttl DAYS
-
-Crawl:
-  --max-concurrent N      Global request concurrency
-  --per-host-concurrent N Per-host request concurrency
-```
-
-## Performance
-
-End-to-end numbers from `tests/benchmarks/test_10k_pages.py` against a
-synthetic 10,000-page localhost site (RAG profile, `max_concurrent=50`,
-`per_host_concurrent=50`, HTTP keep-alive, 5% injected duplicate content).
-The benchmark emits progress every 1,000 pages plus a final JSON report for
-trend tooling. Wall time varies by machine; the value below is the latest
-local audit run.
-
-| Metric | Value |
-|---|---|
-| Total wall time | ~309 s |
-| Pages fetched / skipped / failed | 9,501 / 499 / 0 |
-| Time to first saved page | ~119 ms |
-| Per-page latency p50 / p95 / p99 | ~0 / 168 / 271 ms |
-| Peak RSS delta from baseline | ~93 MB |
-| Cache manifest size on disk | ~8.9 MB |
-| Duplicates detected (5% injected) | 499 / 500 |
-
-Reproduce with `make benchmark` (requires `aiohttp`; runs the gated
-benchmark in `tests/benchmarks/` and prints progress plus a JSON line you can
-pipe into trend tooling).
-
-For real-site and live-provider context-pack benchmarks, use the first-class
-benchmark harness:
-
-```bash
-docpull benchmark quick
-docpull benchmark quick --provider auto --max-estimated-cost 0.05
-docpull benchmark quick --provider all --max-estimated-cost 0.10
-docpull benchmark quick --target-set provider-matrix --provider all \
-  --max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
-  --max-estimated-cost 0.10
-docpull benchmark article .bench/runs/<run>/benchmark.report.json
-```
-
-`docpull benchmark quick` writes `benchmark.report.json` and
-`benchmark.summary.md` under `.bench/runs/<timestamp>/` by default. The core
-cases measure an LLM-profile crawl plus a cached rerun. Passing `--provider auto`
-runs every locally ready provider. Passing `--provider all` requests Parallel,
-Tavily, and Exa, then records missing keys or optional SDKs in
-`skipped_providers` without failing the benchmark. Live Parallel calls still use
-the local `--max-estimated-cost` guard before any work starts.
-
-Use `--target-set tool-docs` to run a cross-pull matrix across the Parallel,
-Exa, Tavily, Raindrop, and DocPull documentation sites. Use `--target-set provider-matrix`
-to add three low-cap adversarial public targets for JS-heavy docs, noisy
-archived navigation, and freshness-sensitive pricing. Matrix runs skip the
-cached core pass by default so the headline grid stays provider x target; pass
-`--cached-pass` to force cache measurement across the matrix.
-
-The compatibility flags `--parallel`, `--tavily`, and `--exa` still work as
-provider aliases. Tavily Search + Extract and Exa Search-with-contents are
-normalized into the same local
-`documents.ndjson`, `corpus.manifest.json`, `sources.md`, provider `*.pack.json`,
-`pack.score.json`, and `source.scores.json` artifacts as the core and Parallel
-cases. The report keeps the legacy pack score and adds weighted benchmark
-sub-scores for coverage, cleanliness, source fidelity, freshness, and density.
-Keys can be exported as `PARALLEL_API_KEY`, `TAVILY_API_KEY`, and `EXA_API_KEY`
-or stored together in `~/.config/docpull/secrets.env`; docpull does not write
-keys into benchmark artifacts.
-
-Tavily usage is credit-based, so set `TAVILY_CREDIT_USD` or pass
-`--tavily-credit-usd` to convert credits into estimated dollars for cost
-comparisons. Without that value, Tavily credits are still recorded in
-`cost_units` but excluded from normalized USD totals.
-
-To trace the benchmark in Raindrop for a publishable observability/eval loop,
-install the optional SDK and pass `--trace raindrop`:
-
-```bash
-pip install 'docpull[parallel,observability]'
-export PARALLEL_API_KEY="<your-parallel-api-key>"
-export TAVILY_API_KEY="<your-tavily-api-key>"
-export TAVILY_CREDIT_USD="<account-credit-value>"
-export EXA_API_KEY="<your-exa-api-key>"
-export RAINDROP_WRITE_KEY="<your-raindrop-write-key>"
-docpull benchmark quick --target-set provider-matrix --provider all --trace raindrop \
-  --max-pages 8 --max-depth 1 --max-search-results 5 --extract-limit 2 \
-  --max-estimated-cost 0.10
-docpull benchmark article .bench/runs/<run>/benchmark.report.json
-```
-
-Raindrop traces are metadata-only by default: docpull records timings, counts,
-scores, costs, selected URLs, provider, workflow, target, prompt, settings, and
-artifact paths, but does not send scraped page content unless a future caller
-explicitly adds that behavior. `RAINDROP_WRITE_KEY` can be exported or stored in
-the same `~/.config/docpull/secrets.env` file as the provider keys.
-
-When Raindrop tracing is enabled, DocPull also emits Raindrop signals for
-attention-worthy benchmark cells: failed cases, low scores, slow cases,
-high-cost cells, and score-dimension warnings. The benchmark report stores the
-Raindrop event id and signal counts so traced runs can be audited later.
+`--require-pinned-dns` to refuse that configuration.
 
 ## Troubleshooting
 
 ```bash
-docpull --doctor              # Check installation
-docpull URL --verbose         # Verbose output
-docpull URL --dry-run         # Test without downloading
-docpull URL --preview-urls    # List URLs without fetching
+docpull --doctor
+docpull URL --verbose
+docpull URL --dry-run
+docpull URL --preview-urls
 ```
+
+## Documentation
+
+- [CLI Recipes](docs/examples/README.md) - common commands and advanced workflows.
+- [Scraping Boundary](docs/scraping-boundary.md) - what docpull does and does not fetch.
+- [Alternatives](docs/alternatives.md) - when to use browser automation or hosted extraction.
+- [Corpus Manifest](docs/corpus-manifest.md) - stable IDs, hashes, and source maps.
+- [Parallel Integration](docs/parallel.md) - live-source context pack workflows.
+- [Changelog](docs/CHANGELOG.md) - release history.
 
 ## Links
 
 - [Website](https://docpull.raintree.technology)
 - [PyPI](https://pypi.org/project/docpull/)
 - [GitHub](https://github.com/raintree-technology/docpull)
-- [Changelog](https://github.com/raintree-technology/docpull/blob/main/docs/CHANGELOG.md)
-- [Release runbook](https://github.com/raintree-technology/docpull/blob/main/docs/release.md)
-- [Metrics](https://github.com/raintree-technology/docpull/blob/main/METRICS.md) — auto-refreshed daily (PyPI downloads, plugin installs via clone count, traffic)
+- [Metrics](METRICS.md)
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.1] - 2026-06-17
+
+### Changed
+- Remove the embedded README demo GIF from the PyPI long description so the
+  project page stays focused on install and usage content.
+- Raise optional MCP dependency floors for `starlette` and `cryptography` so
+  release audits install patched versions.
+
 ## [4.4.0] - 2026-06-16
 
 ### Added

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,7 +1,7 @@
-# DocPull Alternatives And When To Use Each
+# DocPull Alternatives and When to Use Each
 
 DocPull is optimized for one job: turn public static and server-rendered web
-pages into clean, source-linked context for AI agents, RAG/search systems,
+pages into clean, source-linked local context for AI agents, RAG/search systems,
 offline archives, and developer workflows.
 
 Web-source crawling is the core workflow; documentation is one high-value lane,
@@ -37,13 +37,13 @@ tool.
 - Local-first workflows where running a browser or hosted crawler would be too
   heavy, too opaque, or too awkward inside an agent sandbox.
 
-## Where DocPull Is The Wrong Tool
+## Where DocPull Is the Wrong Tool
 
 - JS-only single-page apps where the meaningful content is created after client
   hydration.
 - Sites that require login, form interaction, scrolling interaction, or
   browser state.
-- Anti-bot, captcha, residential proxy, or evasion workflows.
+- CAPTCHA, anti-bot, residential proxy, or evasion workflows.
 - Full custom crawler infrastructure with domain-specific queues, item
   pipelines, or storage backends.
 - Search-engine style discovery across the open web without a provider such as
@@ -75,6 +75,6 @@ If you need a single page inside an agent loop:
 docpull https://example.com/pricing --single
 ```
 
-If you need browser interaction, use a browser automation tool. If you need
-open-web source discovery before extraction, use a search/extract provider and
-then normalize the selected sources into a DocPull context pack.
+If you need browser interaction, use browser automation, such as Playwright. If
+you need open-web source discovery before extraction, use a search/extract
+provider and then normalize the selected sources into a DocPull context pack.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,5 +1,8 @@
 # CLI Recipes
 
+Use these recipes after the 30-second README example when you need a specific
+output format, crawl policy, agent skill, or context-pack workflow.
+
 These examples use the current `docpull` CLI. The old multi-source YAML runner
 and options such as `--sources-file`, `language`, `keep_variant`, TOON output,
 and `create_index` are not part of the current CLI surface.
@@ -51,7 +54,11 @@ docpull https://docs.example.com --format markdown -o ./out/markdown
 docpull https://docs.example.com --format json -o ./out/json
 docpull https://docs.example.com --format ndjson -o ./out/ndjson
 docpull https://docs.example.com --format sqlite -o ./out/sqlite
+docpull https://docs.example.com --format okf -o ./out/okf
 ```
+
+OKF means Open Knowledge Format: a portable Markdown bundle with generated
+indexes, manifests, hashes, metadata, and source-preserving concept files.
 
 ## Claude Code Skill
 

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -36,30 +36,32 @@ context-engineering
 
 ### Tagline
 
-Public web to agent-ready Markdown.
+Turn public documentation sites into local Markdown, NDJSON, and agent-ready
+context packs. No browser required.
 
 ### One-line pitch
 
-DocPull turns public static and server-rendered web pages into clean,
-structured, agent-ready Markdown from a Python CLI, SDK, or MCP server.
+DocPull turns public static and server-rendered documentation/API pages into
+clean local Markdown, NDJSON, and agent-ready context packs from a Python CLI,
+SDK, or MCP server.
 
 ### 50-word description
 
-DocPull is a Python CLI, SDK, and MCP server for pulling public static and
-server-rendered web pages into clean Markdown, NDJSON, and local context packs.
-It avoids browser automation, preserves source metadata, supports chunking for
-LLM/RAG workflows, and includes security protections for agent-selected URLs.
+DocPull is a Python CLI, SDK, and MCP server that fetches public static or
+server-rendered pages and converts them into clean Markdown, NDJSON, and local
+context packs. It avoids browser automation, preserves source metadata, supports
+LLM/RAG chunking, and includes security protections for agent-selected URLs.
 
 ### 150-word description
 
 DocPull is a security-hardened Python tool for turning public static and
 server-rendered web pages into clean, structured context for developers, AI
-agents, and RAG systems. It fetches pages without Playwright, discovers links,
-extracts main content, preserves source metadata, and writes Markdown, NDJSON,
-OKF bundles, SQLite, or local archives. Web-source extraction is the core
-workflow; blogs, vendor pages, API references, OpenAPI specs, docs, and other
-public web content all fit when the content is available without
-JavaScript rendering.
+agents, and retrieval-augmented generation (RAG) systems. It fetches pages
+without Playwright, discovers links, extracts main content, preserves source
+metadata, and writes Markdown, NDJSON, Open Knowledge Format (OKF) bundles,
+SQLite, or local archives. Documentation sites, blogs, vendor pages, API
+references, OpenAPI specs, and other public web content all fit when the useful
+content is available in HTML or embedded page data.
 
 Use it as a CLI, Python SDK, or MCP server. Agents can fetch one URL, crawl a
 site, stream chunked records, cache sources, grep local Markdown, and read exact
@@ -72,13 +74,13 @@ not browser automation; it is the fast, auditable path for clean web context.
 Title:
 
 ```text
-Show HN: DocPull - pull the public web into agent-ready Markdown
+Show HN: DocPull - turn public docs into Markdown, no browser required
 ```
 
 First comment:
 
 ```text
-Hi HN, I built DocPull, a Python CLI/SDK/MCP server for turning public static and server-rendered web pages into clean Markdown and NDJSON for coding agents, RAG indexes, and offline archives.
+Hi HN, I built DocPull, a Python CLI/SDK/MCP server for turning public static and server-rendered documentation/API pages into clean Markdown and NDJSON for coding agents, RAG indexes, and offline archives.
 
 The specific pain: agents often need current web context, but browser automation is heavy, hosted scraping APIs can be overkill, and raw HTML makes poor context. DocPull uses async HTTP, framework-aware extraction, source metadata, chunking, and local caching. It intentionally does not render JavaScript. For public pages that are static or server-rendered, that tradeoff keeps it fast, inspectable, and easy to run in local agent workflows.
 
@@ -95,7 +97,7 @@ I would especially like feedback from people building coding agents, RAG/search 
 
 ## Product Hunt
 
-- Tagline: `Pull public web pages into clean, agent-ready Markdown.`
+- Tagline: `Turn public docs into local Markdown and agent-ready context packs.`
 - Suggested categories: Developer Tools, Open Source, Artificial Intelligence,
   Productivity.
 - Maker comment angle: explain the web-context problem, the no-browser

--- a/docs/marketing-visibility-research.md
+++ b/docs/marketing-visibility-research.md
@@ -2,7 +2,11 @@
 
 Verified on 2026-06-15. This list favors developer traffic, Python relevance, AI-agent/RAG relevance, and credible backlinks over generic directory volume. Some sites block command-line HTTP clients while remaining live in a browser; those are still included only when an official page or search result verified the submission path.
 
-DocPull positioning used for this research: security-hardened, browser-free Python CLI/SDK/MCP server that pulls public static/server-rendered web pages into clean Markdown, NDJSON, OKF bundles, and agent-ready context for LLMs, RAG indexes, source workflows, and offline archives.
+DocPull positioning used for this research: security-hardened, browser-free
+Python CLI/SDK/MCP server that turns public static or server-rendered web pages
+into clean local Markdown, NDJSON, Open Knowledge Format (OKF) bundles, and
+agent-ready context packs for LLMs, RAG indexes, source workflows, and offline
+archives.
 
 ## Priority Table
 
@@ -11,7 +15,7 @@ DocPull positioning used for this research: security-hardened, browser-free Pyth
 | 1 | PyPI project metadata | https://pypi.org/project/docpull/ | Python | Python developers searching packages for scraping, docs, Markdown, CLI tools, and AI workflows | Publish/update release metadata, classifiers, keywords, project URLs, long description | Free | Low | Users, SEO, credibility | Already listed; optimize discovery rather than submit a new listing | `web-scraping`, `documentation`, `markdown`, `rag`, `llm`, `mcp`, `developer-tools` | Pull public web pages into clean, agent-ready Markdown from a Python CLI or SDK. | 5 | https://pypi.org/classifiers/ |
 | 2 | GitHub repo topics | https://github.com/raintree-technology/docpull | OSS | GitHub topic browsers, open-source users, AI-agent builders | Add up to 20 repo topics in GitHub repo metadata | Free | Low | Users, SEO, credibility | Topic names are public; keep them precise and non-spammy | `python`, `web-scraping`, `crawler`, `markdown`, `documentation`, `rag`, `llm`, `mcp-server`, `ai-agents`, `developer-tools`, `cli`, `openapi` | Browser-free Python crawler for turning public web pages into LLM-ready Markdown. | 5 | https://docs.github.com/articles/classifying-your-repository-with-topics |
 | 3 | GitHub release / README launch surface | https://github.com/raintree-technology/docpull | OSS | Developers evaluating the project after any external click | Create a tagged release with crisp notes, screenshots/GIF, examples, comparison links | Free | Medium | Conversion, credibility, feedback | This is the landing page all external submissions will send people to | `python`, `cli`, `mcp`, `agent-context`, `rag`, `docs` | Fast, auditable web-to-Markdown extraction for agents and RAG. | 5 | https://github.com/raintree-technology/docpull |
-| 4 | Hacker News Show HN | https://news.ycombinator.com/showhn.html | Community | High-signal developer feedback, Python/infra builders, LLM builders | Submit a story titled `Show HN: DocPull - pull public web pages into agent-ready Markdown` | Free | Medium | Feedback, users, credibility | Must be something people can try; do not post a landing page only; be present in comments; do not ask for upvotes | `Show HN`, open source, Python, scraping, AI agents | Show HN: I built a browser-free Python tool that pulls public web pages into agent-ready Markdown. | 5 | https://news.ycombinator.com/showhn.html |
+| 4 | Hacker News Show HN | https://news.ycombinator.com/showhn.html | Community | High-signal developer feedback, Python/infra builders, LLM builders | Submit a story titled `Show HN: DocPull - turn public docs into Markdown, no browser required` | Free | Medium | Feedback, users, credibility | Must be something people can try; do not post a landing page only; be present in comments; do not ask for upvotes | `Show HN`, open source, Python, scraping, AI agents | Show HN: I built a browser-free Python tool that turns public docs into local Markdown. | 5 | https://news.ycombinator.com/showhn.html |
 | 5 | Product Hunt | https://www.producthunt.com/launch | Devtool launch | Broad tech launch audience; useful for backlinks/social proof more than deep Python feedback | Create product launch, schedule, upload logo/screenshots/GIF/video, add maker comment | Free core, paid promos optional | High | Backlinks, SEO, users, credibility | One-shot launch dynamic; prepare assets first; developer tools need clear demo | Developer Tools, Open Source, Artificial Intelligence, Productivity | Pull public web pages into clean, structured context for AI agents and RAG. | 4 | https://www.producthunt.com/launch/preparing-for-launch |
 | 6 | DevHunt | https://devhunt.org/ | Devtool launch | Developer-tool audience; more focused than Product Hunt | Submit/list through DevHunt site or GitHub-driven workflow | Free | Medium | Users, feedback, backlinks | Best for devtools; position as CLI/SDK/MCP, not generic AI app | Developer Tools, Open Source, AI, CLI | A Python web crawler that turns web pages into clean context for agents. | 5 | https://github.com/MarsX-dev/devhunt |
 | 7 | Official MCP Registry | https://registry.modelcontextprotocol.io/ | AI directory | MCP clients, agent builders, tool-discovery systems | Publish server metadata using official registry docs/server.json workflow | Free | High | Users, credibility, ecosystem distribution | Requires server metadata quality; local MCP install path must be clear | MCP Server, Documentation, Developer Tools, Web Scraping | Give MCP clients a local tool for fetching and searching public web pages. | 5 | https://modelcontextprotocol.io/registry/about |
@@ -114,29 +118,30 @@ DocPull positioning used for this research: security-hardened, browser-free Pyth
 
 ### 1-line tagline
 
-DocPull turns public websites into clean, structured, agent-ready Markdown.
+DocPull turns public documentation sites into local Markdown, NDJSON, and
+agent-ready context packs.
 
 ### 50-word description
 
-DocPull is a Python CLI, SDK, and MCP server for pulling public static and server-rendered web pages into clean Markdown, NDJSON, and agent-ready context. It crawls fast without browser automation, keeps source metadata, supports chunking for LLM/RAG workflows, and includes security protections for agent-selected URLs.
+DocPull is a Python CLI, SDK, and MCP server that fetches public static or server-rendered pages and converts them into clean Markdown, NDJSON, and agent-ready context packs. It avoids browser automation, keeps source metadata, supports LLM/RAG chunking, and includes security protections for agent-selected URLs.
 
 ### 150-word description
 
-DocPull is a security-hardened Python tool for turning public static and server-rendered web pages into clean, structured context for developers, AI agents, and RAG systems. It fetches pages without Playwright, discovers links, extracts main content, preserves source metadata, and writes Markdown, NDJSON, OKF bundles, or local archives. Web-source extraction is the core workflow; API docs, Docusaurus, Sphinx, MkDocs, Mintlify, Next.js docs, OpenAPI references, vendor pages, blogs, and other public websites fit when the content does not require JavaScript rendering.
+DocPull is a security-hardened Python tool for turning public static and server-rendered web pages into clean, structured context for developers, AI agents, and RAG systems. It fetches pages without Playwright, discovers links, extracts main content, preserves source metadata, and writes Markdown, NDJSON, Open Knowledge Format (OKF) bundles, SQLite, or local archives. Documentation sites, API references, OpenAPI specs, vendor pages, blogs, and other public websites fit when the useful content is available in HTML or embedded page data.
 
 Use it as a CLI, Python SDK, or MCP server. Agents can fetch one URL, crawl a site, stream chunked records, cache sources, grep local Markdown, and read exact files with attribution. SSRF, XXE, DNS-rebinding, and CRLF-injection protections are on by default, because AI agents often choose URLs dynamically. DocPull is not browser automation; it is the fast, auditable path for clean web context.
 
 ### Product Hunt tagline
 
-Pull public web pages into clean, agent-ready Markdown.
+Turn public docs into local Markdown and agent-ready context packs.
 
 ### Show HN title
 
-Show HN: DocPull - pull public web pages into agent-ready Markdown
+Show HN: DocPull - turn public docs into Markdown, no browser required
 
 ### Show HN first comment
 
-Hi HN, I built DocPull, a Python CLI/SDK/MCP server for turning public websites into clean Markdown and NDJSON for coding agents, RAG indexes, and offline archives.
+Hi HN, I built DocPull, a Python CLI/SDK/MCP server for turning public static and server-rendered documentation/API pages into clean Markdown and NDJSON for coding agents, RAG indexes, and offline archives.
 
 The specific pain: agents often need current web context, but browser automation is heavy, hosted scraping APIs can be overkill, and raw HTML makes poor context. DocPull uses async HTTP, framework-aware extraction, source metadata, chunking, and local caching. It intentionally does not render JavaScript. For pages that are static or server-rendered, that tradeoff keeps it fast, inspectable, and easy to run in local agent workflows.
 
@@ -154,13 +159,13 @@ I would especially like feedback from people building coding agents, RAG/search 
 
 ### DevHunt listing copy
 
-DocPull is a Python CLI, SDK, and MCP server that turns public websites into clean, source-linked Markdown for AI agents, RAG pipelines, and developer workflows. It avoids browser automation for the large class of pages that are static or server-rendered, making it fast, local, and easy to audit. Use it to fetch one page, crawl a site, stream LLM-ready chunks, create OKF bundles, or expose web fetching/searching through MCP.
+DocPull is a Python CLI, SDK, and MCP server that turns public static and server-rendered pages into clean, source-linked Markdown for AI agents, RAG pipelines, and developer workflows. It avoids browser automation for the large class of pages where useful content is already available in HTML or embedded page data, making it fast, local, and easy to audit. Use it to fetch one page, crawl a site, stream LLM-ready chunks, create OKF bundles, or expose web fetching/searching through MCP.
 
 Suggested tags: Developer Tools, Open Source, AI, CLI, Python, Documentation, Web Scraping, MCP.
 
 ### Python/GitHub awesome-list PR blurb
 
-Add DocPull, a Python CLI/SDK for crawling public websites and converting them into clean Markdown, NDJSON, and agent-ready context. It is designed for static/server-rendered pages, source-linked extraction, LLM/RAG chunking, and local agent workflows, with SSRF/XXE/DNS-rebinding protections enabled by default.
+Add DocPull, a Python CLI/SDK for crawling public static and server-rendered sites and converting them into clean Markdown, NDJSON, and agent-ready context packs. It is designed for source-linked extraction, LLM/RAG chunking, and local agent workflows, with SSRF/XXE/DNS-rebinding protections enabled by default.
 
 ## Asset Checklist
 

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -1,10 +1,11 @@
 # Parallel Integration
 
-This page cross-references the Parallel products against docpull's 4.1.0
-integration surface. The goal is to make Parallel web intelligence outputs
-durable, local, inspectable, and easy for agents to reuse.
+This page maps Parallel products to docpull's optional context-pack workflows.
+The goal is to make Parallel web intelligence outputs durable, local,
+inspectable, and easy for agents to reuse.
 
-Sources checked on 2026-06-08:
+Parallel sources checked on 2026-06-08. Workflow coverage last reviewed for
+docpull 4.4.0.
 
 - https://docs.parallel.ai/llms.txt
 - https://docs.parallel.ai/public-openapi.json
@@ -58,7 +59,7 @@ estimate, but not `PARALLEL_API_KEY`.
 key is valid; live workflows still fail fast if Parallel rejects the configured
 key.
 
-## Implemented in 4.1.0
+## Implemented Workflows
 
 | Parallel product | Parallel shape | docpull surface | Why it fits |
 | --- | --- | --- | --- |
@@ -76,7 +77,7 @@ key.
 
 | Parallel product | Product fit | Planned docpull workflow |
 | --- | --- | --- |
-| Chat API | OpenAI-compatible live web chat and JSON responses. | Out of scope for docpull 4.1.0 because it is an interactive answer surface, not a context-pack source. |
+| Chat API | OpenAI-compatible live web chat and JSON responses. | Out of scope because it is an interactive answer surface, not a context-pack source. |
 | Data integrations | BigQuery, Snowflake, DuckDB, Spark, Polars, Supabase, Sheets. | Out of scope unless docpull later emits warehouse-friendly pack manifests or imports table rows as source candidates. |
 
 ## Additional Pack Workflows
@@ -213,12 +214,12 @@ Parallel's MCP servers are a separate adoption path:
 - Task MCP requires auth and is useful for deep research and enrichment in MCP-aware clients.
 - Parallel CLI is a direct user/agent tool for searching, extracting, enriching, and monitoring.
 
-docpull 4.1.0 intentionally uses the Python SDK with `docpull[parallel]` and a
-bring-your-own-key model. It does not proxy requests or install MCP servers.
-When users opt in with `docpull parallel init`, the key is stored in local
-machine/project configuration, never in generated packs. That keeps the package
-suitable for open source release while making the outputs durable enough for
-agents, RAG, audits, and demos.
+docpull intentionally uses the Python SDK with `docpull[parallel]` and a
+bring-your-own-key model. It does not proxy requests or install Parallel MCP
+servers. When users opt in with `docpull parallel init`, the key is stored in
+local machine/project configuration, never in generated packs. That keeps the
+package suitable for open source release while making the outputs durable enough
+for agents, RAG, audits, and demos.
 
 ## Controls That Make Packs Useful
 

--- a/docs/scraping-boundary.md
+++ b/docs/scraping-boundary.md
@@ -1,9 +1,9 @@
 # Scraping Boundary
 
-docpull is a browser-free web scraper for turning static and server-rendered
-web pages into local, auditable context artifacts. Its sharpest workflow is
-public web-source ingestion for agents, RAG systems, offline archives, and
-source packs.
+docpull is a browser-free web scraper for turning public static and
+server-rendered web pages into local, auditable context artifacts. Its sharpest
+workflow is public web-source ingestion for agents, retrieval-augmented
+generation (RAG) systems, offline archives, and source packs.
 
 ## What docpull should do
 
@@ -37,8 +37,8 @@ browser-free default remains unchanged.
 
 - Use Scrapy when you need a programmable spider framework with custom item
   pipelines.
-- Use Crawlee when browser automation, sessions, queues, and anti-blocking
-  workflows are the core job.
+- Use Playwright, Puppeteer, Selenium, or Crawlee when browser automation,
+  sessions, queues, and interaction are the core job.
 - Use a hosted extraction service when you want managed rendering, proxies, and
   external infrastructure.
 - Use trafilatura directly when you only need article text extraction and do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "4.4.0"
+version = "4.4.1"
 dynamic = []
 description = "Convert public web pages into clean Markdown for AI agents and RAG"
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -101,10 +101,11 @@ tokens = [
     "tiktoken>=0.7.0",
 ]
 mcp = [
+    "cryptography>=48.0.1",
     "mcp>=1.0.0",
     "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",
 ]
 parallel = [
     "parallel-web>=1.0.1",
@@ -120,10 +121,11 @@ all = [
     "url-normalize>=1.4.0",
     "trafilatura>=1.12.0",
     "tiktoken>=0.7.0",
+    "cryptography>=48.0.1",
     "mcp>=1.0.0",
     "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",
     "parallel-web>=1.0.1",
     "raindrop-ai>=0.0.50",
 ]

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "4.4.0"
+__version__ = "4.4.1"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .conversion.chunking import Chunk, TokenCounter, chunk_markdown

--- a/tests/benchmarks/test_10k_pages.py
+++ b/tests/benchmarks/test_10k_pages.py
@@ -1,8 +1,7 @@
 """End-to-end benchmark: 10,000 synthetic pages over localhost HTTP.
 
-Numbers this benchmark produces are the ones we will publish in the
-README under "Performance." They cover what the plan calls the
-falsifiable scaling claim:
+Numbers this benchmark produces feed release notes, benchmark reports, and
+marketing material when we need a falsifiable scaling claim:
 
 - Wall time (full crawl, sitemap-driven)
 - Peak RSS delta from baseline (via stdlib resource.getrusage)


### PR DESCRIPTION
Prepares docpull 4.4.1 for PyPI.\n\nChanges:\n- Remove the embedded README demo GIF from the PyPI long description.\n- Refresh README/docs positioning around public documentation context packs.\n- Raise optional MCP dependency floors for patched Starlette and cryptography versions.\n\nLocal gates run:\n- ruff check .\n- ruff format --check .\n- mypy src\n- pytest -q\n- pip-audit\n- python -m bandit -q -c pyproject.toml -r src\n- python -m build --no-isolation\n- python -m twine check dist/*