### PR TITLE
ci: harden package release gates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           DOCPULL_BENCHMARK_10K: "1"
         run: |
-          PYTHONPATH=src pytest -v -s tests/benchmarks/test_10k_pages.py \
+          PYTHONPATH=src python -m pytest -v -s tests/benchmarks/test_10k_pages.py \
             | tee benchmark.log
 
       - name: Surface report in summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # pyproject.toml claims 3.10-3.14 support, but actions/setup-python
-        # may not have stable 3.14 in its release manifest yet, so leave 3.14
-        # out for now. Add it back once setup-python ships a stable 3.14.
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -50,8 +47,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]"
 
+      - name: Run tests
+        if: matrix.python-version != '3.11'
+        run: python -m pytest -q
+
       - name: Run tests with coverage
-        run: pytest --cov=docpull --cov-report=xml --cov-report=term -q
+        if: matrix.python-version == '3.11'
+        run: python -m pytest --cov=docpull --cov-report=xml --cov-report=term -q
 
       - name: Upload coverage XML
         if: matrix.python-version == '3.11'
@@ -79,13 +81,13 @@ jobs:
           pip install -e ".[all,dev]"
 
       - name: Run ruff
-        run: ruff check .
+        run: python -m ruff check .
 
       - name: Check formatting
-        run: ruff format --check .
+        run: python -m ruff format --check .
 
       - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
+        run: python -m pre_commit run --all-files --show-diff-on-failure
 
   typecheck:
     runs-on: ubuntu-24.04
@@ -106,4 +108,36 @@ jobs:
           pip install -e ".[all,dev]"
 
       - name: Run mypy
-        run: mypy src
+        run: python -m mypy src
+
+  package:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-release.txt
+
+      - name: Install pinned release tooling
+        run: python -m pip install -r requirements-release.txt
+
+      - name: Build wheel and sdist
+        run: python -m build --no-isolation
+
+      - name: Verify wheel and sdist metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke install built wheel
+        run: |
+          python -m venv .pkg-smoke
+          .pkg-smoke/bin/python -m pip install --upgrade pip
+          .pkg-smoke/bin/python -m pip install dist/*.whl
+          .pkg-smoke/bin/docpull --version
+          .pkg-smoke/bin/python -c "import docpull; print(docpull.__version__)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,19 +82,26 @@ jobs:
 
       - name: Run release gates
         run: |
-          ruff check .
-          ruff format --check .
-          mypy src
-          pytest -q
-          pip-audit
-          bandit -q -c pyproject.toml -r src
+          python -m ruff check .
+          python -m ruff format --check .
+          python -m mypy src
+          python -m pytest -q
+          python -m pip_audit
+          python -m bandit -q -c pyproject.toml -r src scripts
 
       - name: Build distributions
-        run: |
-          python -m build --no-isolation
+        run: python -m build --no-isolation
 
       - name: Verify wheel and sdist
         run: python -m twine check dist/*
+
+      - name: Smoke install built wheel
+        run: |
+          python -m venv .release-smoke
+          .release-smoke/bin/python -m pip install --upgrade pip
+          .release-smoke/bin/python -m pip install dist/*.whl
+          .release-smoke/bin/docpull --version
+          .release-smoke/bin/python -c "import docpull; print(docpull.__version__)"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,13 +48,13 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Audit Python dependencies
-        run: pip-audit
+        run: python -m pip_audit
 
       - name: Run Bandit
-        run: bandit -q -c pyproject.toml -r src
+        run: python -m bandit -q -c pyproject.toml -r src scripts
 
       - name: Run Python security regression tests
-        run: PYTHONPATH=src pytest -q tests/test_security_hardening.py tests/test_discovery.py tests/test_integration.py
+        run: PYTHONPATH=src python -m pytest -q tests/test_security_hardening.py tests/test_discovery.py tests/test_integration.py
 
   mcp-security:
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy src
+        entry: python3 scripts/precommit_mypy.py
         language: system
         pass_filenames: false
         types: [python]

--- a/scripts/precommit_mypy.py
+++ b/scripts/precommit_mypy.py
@@ -1,0 +1,33 @@
+"""Run mypy from the project interpreter for pre-commit."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _project_python(repo_root: Path) -> str:
+    if os.name == "nt":
+        venv_python = repo_root / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = repo_root / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    os.chdir(repo_root)
+    python = _project_python(repo_root)
+    # Selected Python executable with static mypy argv; no shell.
+    os.execv(  # nosec B606
+        python,
+        [python, "-m", "mypy", "src"],
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
+
+# Bandit B404: release helper invokes fixed git/gh argument lists without shell.
 
 try:
     import tomllib
@@ -18,7 +20,8 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def run(*args: str, capture: bool = False, check: bool = True) -> str:
-    proc = subprocess.run(
+    # Fixed argv from release helpers; shell remains disabled.
+    proc = subprocess.run(  # nosec B603
         args,
         cwd=ROOT,
         check=False,

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -12,6 +12,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 USE_RE = re.compile(r"uses:\s*([^@\s]+)@([^\s]+)")
+PYTHON_CLASSIFIER_RE = re.compile(r'"Programming Language :: Python :: (3\.\d+)"')
+CI_MATRIX_RE = re.compile(r"python-version:\s*\[(?P<versions>[^\]]+)\]")
 
 
 def test_github_actions_are_pinned_to_full_commit_shas() -> None:
@@ -44,6 +46,75 @@ def test_publish_workflow_accepts_only_tags_or_guarded_manual_dispatch() -> None
     assert 'elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then' in publish
     assert 'if [ "${GITHUB_REF_NAME}" != "main" ]; then' in publish
     assert 'if [ "$REQUESTED_VERSION" != "$PROJECT_VERSION" ]; then' in publish
+
+
+def test_ci_matrix_covers_advertised_python_minors() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+    ci = (WORKFLOW_DIR / "ci.yml").read_text()
+
+    advertised = set(PYTHON_CLASSIFIER_RE.findall(pyproject))
+    matrix_match = CI_MATRIX_RE.search(ci)
+    assert matrix_match is not None
+    tested = set(re.findall(r'"(3\.\d+)"', matrix_match.group("versions")))
+
+    assert tested == advertised
+
+
+def test_ci_builds_checks_and_smoke_installs_distribution() -> None:
+    ci = (WORKFLOW_DIR / "ci.yml").read_text()
+
+    assert "\n  package:\n" in ci
+    assert "python -m pip install -r requirements-release.txt" in ci
+    assert "python -m build --no-isolation" in ci
+    assert "python -m twine check dist/*" in ci
+    assert "python -m venv .pkg-smoke" in ci
+    assert ".pkg-smoke/bin/python -m pip install dist/*.whl" in ci
+    assert ".pkg-smoke/bin/docpull --version" in ci
+
+
+def test_publish_workflow_smoke_installs_distribution_before_upload() -> None:
+    publish = (WORKFLOW_DIR / "publish.yml").read_text()
+
+    assert "python -m venv .release-smoke" in publish
+    assert ".release-smoke/bin/python -m pip install dist/*.whl" in publish
+    assert ".release-smoke/bin/docpull --version" in publish
+
+
+def test_security_and_publish_bandit_scan_scripts() -> None:
+    security = (WORKFLOW_DIR / "security.yml").read_text()
+    publish = (WORKFLOW_DIR / "publish.yml").read_text()
+
+    assert "python -m bandit -q -c pyproject.toml -r src scripts" in security
+    assert "python -m bandit -q -c pyproject.toml -r src scripts" in publish
+
+
+def test_workflows_use_module_entrypoints_for_python_tooling() -> None:
+    raw_tool_prefixes = (
+        "ruff ",
+        "mypy ",
+        "pytest ",
+        "pip-audit",
+        "bandit ",
+        "pre-commit ",
+    )
+    env_prefix_re = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+")
+    offenders: list[str] = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            stripped = line.strip()
+            command = stripped.removeprefix("run: ")
+            command = env_prefix_re.sub("", command)
+            if command.startswith(raw_tool_prefixes):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {stripped}")
+
+    assert offenders == []
+
+
+def test_pre_commit_mypy_uses_project_interpreter_wrapper() -> None:
+    config = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+
+    assert "entry: python3 scripts/precommit_mypy.py" in config
+    assert "entry: mypy src" not in config
 
 
 def test_plugin_readme_cache_path_matches_mcp_default() -> None:


### PR DESCRIPTION
## Summary
- test every advertised Python minor, including 3.14
- add PR-time wheel/sdist build, twine check, and clean wheel smoke install
- harden publish/security workflows with module entrypoints and script-scoped Bandit
- make pre-commit mypy use the project interpreter and add policy tests to prevent CI drift

## Validation
- python -m pytest -q
- python -m pre_commit run --all-files --show-diff-on-failure
- python -m mypy src scripts/precommit_mypy.py
- python -m bandit -q -c pyproject.toml -r src scripts
- python -m pip_audit
- temp build + twine check + clean wheel install smoke
- Python 3.14.5 temp venv install with .[all,dev] + targeted tests