### PR TITLE
Fix PyPI publish workflow startup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Read pyproject.toml version (and verify tag match on tag push)
         id: meta
         env:
-          REQUESTED_VERSION: ${{ inputs.version || '' }}
+          REQUESTED_VERSION: ${{ github.event.inputs.version || '' }}
         run: |
           set -e
           PROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: pypi
-      url: https://pypi.org/project/docpull/${{ needs.build.outputs.version }}/
+      url: https://pypi.org/project/docpull/
     permissions:
       id-token: write  # Required for OIDC / trusted publishing
     steps:


### PR DESCRIPTION
## Summary

Fixes the trusted PyPI publish workflow startup failure seen after pushing `v5.5.0`.

- uses `github.event.inputs.version` for manual dispatch input lookup
- makes the PyPI environment URL static so the workflow does not depend on a startup-time `needs` expression

## Validation

- `git diff --check`
- This PR's normal CI/security ruleset will validate the workflow file on merge.

## Release note

After this merges, replace the early failed `v5.5.0` tag with `make release-publish-replace-tag VERSION=5.5.0` because the first tag run failed before any publish job started.
