### PR TITLE
Fix release surface updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,6 +136,7 @@ jobs:
       name: pypi
       url: https://pypi.org/project/docpull/
     permissions:
+      contents: write  # Required to create/update the GitHub Release after publish
       id-token: write  # Required for OIDC / trusted publishing
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -147,3 +148,30 @@ jobs:
         with:
           packages-dir: dist/
           # No password: trusted publishing via OIDC
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+
+      - name: Create GitHub release
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          RELEASE_TITLE="docpull ${VERSION}"
+          MINOR_VERSION="${VERSION%.*}"
+          NOTES_FILE="docs/release-post-v${MINOR_VERSION}.md"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            if [ -f "$NOTES_FILE" ]; then
+              gh release edit "$TAG" --title "$RELEASE_TITLE" --latest --notes-file "$NOTES_FILE"
+            else
+              gh release edit "$TAG" --title "$RELEASE_TITLE" --latest
+            fi
+          elif [ -f "$NOTES_FILE" ]; then
+            gh release create "$TAG" --title "$RELEASE_TITLE" --verify-tag --latest --notes-file "$NOTES_FILE"
+          else
+            gh release create "$TAG" --title "$RELEASE_TITLE" --verify-tag --latest --generate-notes
+          fi

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Keep AI agents synced with changing public docs. Browser-free by default.**
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI version](https://badge.fury.io/py/docpull.svg)](https://badge.fury.io/py/docpull)
+[![PyPI version](https://img.shields.io/pypi/v/docpull.svg?label=package)](https://pypi.org/project/docpull/)
 [![PyPI downloads](https://img.shields.io/pepy/dt/docpull?label=downloads)](https://pepy.tech/project/docpull)
 [![GitHub stars](https://img.shields.io/github/stars/raintree-technology/docpull?style=social)](https://github.com/raintree-technology/docpull/stargazers)
 [![License: MIT](https://img.shields.io/github/license/raintree-technology/docpull)](https://github.com/raintree-technology/docpull/blob/main/LICENSE)

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,7 +56,23 @@ make release-publish VERSION=5.0.0
 
 This verifies `origin/main` has the requested `pyproject.toml` version, puts
 `vX.Y.Z` on the merged `origin/main` commit, and pushes the tag to start the
-PyPI workflow. It refuses to move an existing remote tag by default.
+PyPI workflow. After the PyPI trusted-publish step succeeds on a tag push, the
+workflow creates or updates the GitHub Release for that tag and marks it as the
+latest release. It uses `docs/release-post-vX.Y.md` when present and otherwise
+falls back to generated notes.
+
+Verify both public release surfaces:
+
+```bash
+gh release view v5.0.0 --json tagName,name,publishedAt,url
+python - <<'PY'
+import json, urllib.request
+with urllib.request.urlopen("https://pypi.org/pypi/docpull/json", timeout=20) as r:
+    print(json.load(r)["info"]["version"])
+PY
+```
+
+The helper refuses to move an existing remote tag by default.
 
 If a tag was pushed early and the publish workflow did not complete, first
 confirm the version was not published on PyPI, then run:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -124,6 +124,32 @@ def test_publish_workflow_builds_artifact_before_unlocked_release_gates() -> Non
     assert "needs: [build, release-gates]" in publish_section
 
 
+def test_publish_workflow_creates_github_release_after_pypi_publish() -> None:
+    publish = (WORKFLOW_DIR / "publish.yml").read_text()
+    _, publish_section = publish.split("\n  publish:\n", 1)
+
+    assert "contents: write" in publish_section
+    assert "id-token: write" in publish_section
+    assert "pypa/gh-action-pypi-publish@release/v1" in publish_section
+    assert "name: Create GitHub release" in publish_section
+    assert "if: github.event_name == 'push' && github.ref_type == 'tag'" in publish_section
+    assert "GH_TOKEN: ${{ github.token }}" in publish_section
+    assert 'NOTES_FILE="docs/release-post-v${MINOR_VERSION}.md"' in publish_section
+    assert (
+        'gh release edit "$TAG" --title "$RELEASE_TITLE" --latest --notes-file "$NOTES_FILE"'
+        in publish_section
+    )
+    assert 'gh release edit "$TAG" --title "$RELEASE_TITLE" --latest' in publish_section
+    assert (
+        'gh release create "$TAG" --title "$RELEASE_TITLE" --verify-tag --latest --notes-file "$NOTES_FILE"'
+        in publish_section
+    )
+    assert (
+        'gh release create "$TAG" --title "$RELEASE_TITLE" --verify-tag --latest --generate-notes'
+        in publish_section
+    )
+
+
 def test_security_and_publish_bandit_scan_scripts() -> None:
     security = (WORKFLOW_DIR / "security.yml").read_text()
     publish = (WORKFLOW_DIR / "publish.yml").read_text()


### PR DESCRIPTION
## Summary
- create or update the GitHub Release after a successful tag-based trusted PyPI publish
- switch the README package badge to the PyPI shield URL so GitHub gets a fresh badge source
- document release-surface verification and cover the workflow behavior in CI policy tests

## Verification
- `/Users/mb1/Code/raintree/docpull/.venv/bin/python -m pytest tests/test_ci_policy.py -q`
- `/Users/mb1/Code/raintree/docpull/.venv/bin/python -m ruff check tests/test_ci_policy.py`
- `/Users/mb1/Code/raintree/docpull/.venv/bin/python -m ruff format --check tests/test_ci_policy.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "yaml ok"'`

Note: `actionlint` is not installed in this local environment; GitHub Actions will validate workflow parsing in CI.
