### PR TITLE
Release 5.5.1 hotfix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [5.5.1] - 2026-06-29
+
+### Fixed
+- Restore `screenshot-pack` compatibility with the current `agent-browser`
+  command contract by falling back to batch JSON/file-output capture.
+- Write durable `search-pack` replay config metadata for local, dry-run,
+  budget-blocked, and provider-backed search paths.
+
 ## [5.5.0] - 2026-06-29
 
 ### Added

--- a/docs/release-post-v5.5.md
+++ b/docs/release-post-v5.5.md
@@ -1,5 +1,14 @@
 # DocPull v5.5: Typed Local Context Packs
 
+## v5.5.1 Hotfix
+
+DocPull v5.5.1 ships the post-release fixes from the real-data validation pass:
+`screenshot-pack` now works with the current `agent-browser` command contract,
+and `search-pack` now writes replay config metadata across local, dry-run,
+budget-blocked, and provider-backed paths.
+
+## v5.5.0
+
 DocPull v5.5 adds local-first context packs for brand, design, product,
 structured extraction, visual assets, screenshots, and search.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docpull",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Pull public web sources into Claude Code. Indexes static and server-rendered sites as local Markdown with conditional-GET caching, then exposes them as MCP tools. Local, browser-free, no API keys.",
   "author": {
     "name": "Raintree Technology",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "docpull",
   "name": "docpull",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Pull public web sources into Codex as local, searchable Markdown through docpull's MCP server.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -31,7 +31,7 @@ MCP server is available:
 ```bash
 pip install 'docpull[mcp]'          # or: pipx install 'docpull[mcp]'
                                     #     uv tool install 'docpull[mcp]'
-docpull --version                   # should print 5.5.0 or newer
+docpull --version                   # should print 5.5.1 or newer
 docpull mcp --help                  # confirm the MCP subcommand is wired
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "5.5.0"
+version = "5.5.1"
 dynamic = []
 description = "Keep AI agents synced with changing public docs and web sources"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "5.5.0"
+__version__ = "5.5.1"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .context_packs import (


### PR DESCRIPTION
## Summary
- bump docpull to 5.5.1
- add changelog and release-post notes for the screenshot/search hotfix
- sync generated plugin metadata to 5.5.1

## Validation
- scripts/sync_release_metadata.py --check
- ruff check .
- ruff format --check .
- mypy src
- pytest -q: 800 passed, 3 skipped
- python -m build --no-isolation
- twine check dist/*
- pip-audit: no known vulnerabilities found
- bandit -q -c pyproject.toml -r src scripts
- smoke-installed built wheel and verified docpull 5.5.1
