### PR TITLE
chore(release): prepare 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 [![GitHub stars](https://img.shields.io/github/stars/raintree-technology/docpull?style=social)](https://github.com/raintree-technology/docpull/stargazers)
 [![License: MIT](https://img.shields.io/github/license/raintree-technology/docpull)](https://github.com/raintree-technology/docpull/blob/main/LICENSE)
 
+<!-- mcp-name: io.github.raintree-technology/docpull -->
+
 DocPull is a local-first dependency manager for AI context. Define the public
-docs and web sources an agent depends on, sync them into cited context packs,
-diff what changed, and export reproducible context for Cursor, Claude, Codex,
-OpenAI, LlamaIndex, LangChain, MCP clients, and RAG pipelines.
+web sources an agent depends on, sync them into cited context packs, diff what
+changed, and export reproducible context for Cursor, Claude, OpenAI,
+LlamaIndex, LangChain, MCP clients, and RAG pipelines.
 
 The core workflow is a `docpull.yaml` plus a `.docpull/context.lock.json`,
 similar in spirit to code dependency manifests and lockfiles:
@@ -23,7 +25,7 @@ docpull install
 docpull deps
 docpull sync
 docpull diff
-docpull export context-pack --target codex
+docpull export context-pack --target openai
 ```
 
 Bundled aliases such as `stripe`, `react`, `postgres`, `openai`, and
@@ -386,12 +388,11 @@ More examples live in [CLI Recipes](docs/examples/README.md).
 With an explicit `--skill-agent`, docpull stores the fetched corpus under
 `.docpull/skills/<name>/references` and creates agent-specific wrappers that
 point at that corpus. `--skill-agent claude` writes a Claude Code skill under
-`.claude/skills/<name>/`, `--skill-agent codex` writes a Codex skill under
-`.agents/skills/<name>/` with `agents/openai.yaml`, and `--skill-agent cursor`
-writes a Cursor project rule at `.cursor/rules/<name>.mdc`. Use
-`--skill-agent all` to create all three. If you pass `--output-dir`, docpull
-stages the generated corpus there; explicit `--skill-agent` targets still write
-their active agent wrappers.
+`.claude/skills/<name>/`, and `--skill-agent cursor` writes a Cursor project
+rule at `.cursor/rules/<name>.mdc`. Use `--skill-agent all` to create every
+supported wrapper. If you pass `--output-dir`, docpull stages the generated
+corpus there; explicit `--skill-agent` targets still write their active agent
+wrappers.
 
 Use docpull when you need to:
 
@@ -601,7 +602,7 @@ part of the package release contract.
 - `docpull export` writes local files for OpenAI vector JSONL, LangChain,
   LlamaIndex, DSPy, Sheets CSV/TSV, n8n workflow JSON, Vercel AI SDK JSON,
   CrewAI JSON, warehouse NDJSON, optional Parquet via `docpull[parquet]`, and
-  Codex/Claude/Cursor agent references.
+  agent reference bundles.
 ## Security Defaults
 
 - HTTPS-only fetching with robots.txt compliance.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docpull",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Pull public web sources into Claude Code. Indexes static and server-rendered sites as local Markdown with conditional-GET caching, then exposes them as MCP tools. Local, browser-free, no API keys.",
   "author": {
     "name": "Raintree Technology",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "docpull",
   "name": "docpull",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Pull public web sources into Codex as local, searchable Markdown through docpull's MCP server.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -31,7 +31,7 @@ MCP server is available:
 ```bash
 pip install 'docpull[mcp]'          # or: pipx install 'docpull[mcp]'
                                     #     uv tool install 'docpull[mcp]'
-docpull --version                   # should print 6.0.0 or newer
+docpull --version                   # should print 6.0.1 or newer
 docpull mcp --help                  # confirm the MCP subcommand is wired
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "6.0.0"
+version = "6.0.1"
 dynamic = []
 description = "Declare, sync, diff, and lock context dependencies for AI agents"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.raintree-technology/docpull",
+  "title": "DocPull",
+  "description": "Sync public web sources into cited context packs for AI agents, RAG, and MCP clients.",
+  "repository": {
+    "url": "https://github.com/raintree-technology/docpull",
+    "source": "github"
+  },
+  "websiteUrl": "https://docpull.raintree.technology",
+  "version": "6.0.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "docpull",
+      "version": "6.0.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -1,5 +1,5 @@
 """
-docpull - Fetch and convert static/server-rendered web content to markdown.
+docpull - Context dependencies for AI agents.
 
 Usage:
     from docpull import Fetcher, DocpullConfig, ProfileName
@@ -14,7 +14,7 @@ Usage:
             print(event)
 """
 
-__version__ = "6.0.0"
+__version__ = "6.0.1"
 
 from .cache import CacheManager, StreamingDeduplicator
 from .context_ci import CIThresholds, ContextCIError, run_context_ci


### PR DESCRIPTION
Prepares docpull 6.0.1 for MCP Registry publication.\n\nChanges:\n- Add the MCP Registry PyPI ownership marker to README.\n- Add root server.json for io.github.raintree-technology/docpull.\n- Bump package and generated release metadata to 6.0.1.\n- Keep public README/PyPI copy positioned around public web context packs for agents/RAG/MCP clients.\n\nLocal checks:\n- mcp-publisher validate\n- python scripts/sync_release_metadata.py --check\n- python -m build\n- twine check dist/*\n- verified built wheel metadata contains mcp-name marker