### PR TITLE
Fix 6.3 release scorecard environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,8 @@ jobs:
 
       - name: Run A+ release scorecard
         run: |
-          uv run --locked python scripts/release_a_plus_check.py \
+          uv run --locked --all-extras --with-requirements requirements-release.txt \
+            python scripts/release_a_plus_check.py \
             --strict \
             --output-dir "$RUNNER_TEMP/release-readiness" \
             --smoke-report "$RUNNER_TEMP/release-readiness/real-feature-smoke/real_feature_smoke.report.json"

--- a/scripts/release_a_plus_check.py
+++ b/scripts/release_a_plus_check.py
@@ -604,10 +604,9 @@ def _planned_command_names(repo: Path) -> list[str]:
 
 def create_parser() -> argparse.ArgumentParser:
     repo_default = Path(__file__).resolve().parents[1]
-    venv_python = repo_default / ".venv" / "bin" / "python"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, default=repo_default)
-    parser.add_argument("--python", default=str(venv_python if venv_python.exists() else sys.executable))
+    parser.add_argument("--python", default=sys.executable)
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--strict", action="store_true")
     parser.add_argument("--quick", action="store_true", help="Pass --quick to the real-feature smoke")

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -168,6 +168,10 @@ def test_publish_workflow_builds_artifact_before_locked_release_gates() -> None:
     assert 'pip install --no-build-isolation -e ".[all,dev]"' not in build_section
 
     assert "uv sync --locked --all-extras" in gate_section
+    assert (
+        "uv run --locked --all-extras --with-requirements requirements-release.txt "
+        "python scripts/release_a_plus_check.py"
+    ) in gate_section.replace("\\\n            ", "")
     assert "uv run --locked python scripts/sync_release_metadata.py --check" in publish
     assert "actions/download-artifact" in gate_section
     assert "uv venv .release-smoke" in publish

--- a/tests/test_release_a_plus_check_script.py
+++ b/tests/test_release_a_plus_check_script.py
@@ -50,6 +50,12 @@ def test_release_a_plus_plan_mode_is_side_effect_free() -> None:
     assert "--full-mcp" in payload["smoke_command"]
 
 
+def test_release_a_plus_defaults_to_the_invoking_python() -> None:
+    module = _load_scorecard_module()
+
+    assert module.create_parser().parse_args(["--plan-only"]).python == sys.executable
+
+
 def test_release_a_plus_activates_web_gates_only_when_web_package_exists(tmp_path: Path) -> None:
     module = _load_scorecard_module()
 


### PR DESCRIPTION
## Summary
- run the A+ scorecard with all locked project extras and pinned release tooling
- make the scorecard use the Python interpreter that invoked it instead of silently switching to an incomplete local venv
- add policy coverage for the release invocation and interpreter contract

## Validation
- 26 focused CI/release tests passed
- exact strict A+ scorecard replay against the successful 6.3 real-feature smoke: `all_a_plus=True`
- Ruff and formatting passed