### PR TITLE
Fix release gate tooling sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,9 @@ jobs:
         run: python -m pip install "uv==$UV_VERSION"
 
       - name: Sync release gate dependencies
-        run: uv sync --locked --all-extras
+        run: |
+          uv sync --locked --all-extras
+          uv pip install --python .venv/bin/python --requirements requirements-release.txt
 
       - name: Install local render runtime
         run: |


### PR DESCRIPTION
## What changed

- install the pinned release tool requirements into the release-gate virtual environment
- keep the existing locked project and extras sync unchanged

## Why

The v6.3.0 publish run built the distributions successfully, but the A+ scorecard launched `scripts/build_release.py` and `twine` from `.venv`, where neither package had been installed. That made `package_build` and `twine_check` fail and skipped trusted publishing.

## Validation

- parsed `.github/workflows/publish.yml` with PyYAML
- installed `requirements-release.txt` into `.venv` with the exact workflow command
- imported `build==1.5.0` and `twine==6.2.0` from that environment
- `git diff --check`
- commit-time gitleaks scan
