### PR TITLE
Make stale metrics advisory in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,9 @@ jobs:
         env:
           METRICS_MAX_AGE_HOURS: "168"
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            uv run --locked python .github/scripts/check_metrics_fresh.py || {
-              echo "::warning::Metrics are stale; run the scheduled Update metrics workflow after merge."
-            }
-          else
-            uv run --locked python .github/scripts/check_metrics_fresh.py
-          fi
+          uv run --locked python .github/scripts/check_metrics_fresh.py || {
+            echo "::warning::Metrics are stale; run the scheduled Update metrics workflow."
+          }
 
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The scheduled metrics refresh is currently blocked by an expired `METRICS_TOKEN` and upstream HTTP 429. Metrics freshness is repository telemetry, not a code/package correctness gate. Keep the check and warning visible, but do not fail otherwise-green `main` builds.

Validation: `tests/test_ci_policy.py` (8 passed), pre-commit, diff check.