### PR TITLE
fix: include website pack in MCP surface

### DIFF
--- a/src/docpull/surface.py
+++ b/src/docpull/surface.py
@@ -296,6 +296,7 @@ PUBLIC_MCP_TOOLS = frozenset(
         "grep_docs",
         "read_doc",
         "workflow_run",
+        "website_pack",
         "brand_pack",
         "product_pack",
         "styleguide_pack",


### PR DESCRIPTION
The v6.4.0 publish gate found that the registered `website_pack` tool was missing from `PUBLIC_MCP_TOOLS`, causing the full MCP release smoke to fail. This adds the registered tool to the canonical surface contract.\n\nVerification: `uv run --locked --extra dev pytest tests/test_surface_contract.py -q` (12 passed).