### PR TITLE
Finish automation cleanup

### DIFF
--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -118,7 +118,6 @@ def test_production_workflows_keep_automatic_triggers() -> None:
     benchmark = (WORKFLOW_DIR / "benchmark.yml").read_text()
     live_typed = (WORKFLOW_DIR / "live-typed-packs.yml").read_text()
     live_web = (WORKFLOW_DIR / "live-web-smoke.yml").read_text()
-    metrics = (WORKFLOW_DIR / "metrics.yml").read_text()
 
     for workflow in (ci, codeql, security):
         assert "pull_request:" in workflow
@@ -128,7 +127,6 @@ def test_production_workflows_keep_automatic_triggers() -> None:
     assert 'cron: "17 4 * * 3"' in benchmark
     assert 'cron: "17 11 * * *"' in live_typed
     assert 'cron: "43 10 * * *"' in live_web
-    assert 'cron: "12 9 * * 1"' in metrics
 
 
 def test_uv_lock_is_committed_and_used() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4440,11 +4440,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Removes the stale test assertion for the retired metrics bot and updates the locked packaging tool to its patched release.