### PR TITLE
Release DocPull 6.5.1

### DIFF
--- a/bench/baselines/controlled-v2.fixture.json
+++ b/bench/baselines/controlled-v2.fixture.json
@@ -1911,13 +1911,13 @@
       "status": "observed"
     }
   },
-  "environment_label": "local",
-  "previous_sha256": "dc9dd194dd7697d9042808fc6d3dd4d64e1a1834d361b5eb22b8aa90c04a384e",
-  "protocol_sha256": "2e5ffbea044154e4e2e4f196cd4d2d2910228853ac1706afa167bb11fb2315eb",
-  "reason": "scorer v5 token economics diagnostic metrics",
+  "environment_label": "ci-container",
+  "previous_sha256": "323f501c1b99848a57a6d91c60dbfe148545a094c511000872483f42705ebcab",
+  "protocol_sha256": "ae20642617060436c544a5a17e3dce02d06f3fe978fd55a2d000ace5c63c0770",
+  "reason": "Align the controlled baseline with the committed v5 scorer protocol used by DocPull 6.5.1.",
   "schema_version": 2,
-  "source_report_sha256": "24c0b2e8b38a25b65f5ee0b5dcc85d9aa0d92d58ee05899f896053e64dac26b5",
+  "source_report_sha256": "d99ac67947588254ee388a31049d8df2e62d87e48ed45f40dd16d41b0abe3f27",
   "suite_sha256": "21ea6cca08e27dcb7f52d1ebc6b38f969949240576ac9b6a1b13a1aa3374d639",
   "system": "fixture",
-  "updated_at": "2026-07-22T03:30:30.077676+00:00"
+  "updated_at": "2026-09-04T21:04:23.861629+00:00"
 }

--- a/bench/uv.lock
+++ b/bench/uv.lock
@@ -848,7 +848,7 @@ wheels = [
 
 [[package]]
 name = "docpull"
-version = "6.5.0"
+version = "6.5.1"
 source = { editable = "../" }
 dependencies = [
     { name = "aiohttp" },
@@ -883,8 +883,8 @@ requires-dist = [
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'markitdown'", specifier = ">=0.1.0" },
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'parse'", specifier = ">=0.1.0" },
-    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1" },
+    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.28.1,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1,<2" },
     { name = "msgpack", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.0.0" },

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "sdk/js": {
       "name": "@raintree-technology/docpull-sdk",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "devDependencies": {
         "@types/node": "^25.9.1",
         "typescript": "^6.0.3",
@@ -37,10 +37,11 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.11",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "postcss": "^8.5.10",
+    "qs": "6.16.0",
   },
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
@@ -129,7 +130,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -229,7 +230,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.1] - 2026-09-04
+
+### Fixed
+- Constrain the optional MCP runtime to the compatible 1.x series. This prevents
+  fresh `docpull[mcp]` installations from resolving MCP 2.x, whose low-level
+  server API is incompatible with DocPull 6.5.
+
 ## [6.4.0] - 2026-07-16
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -28,11 +28,11 @@
   "overrides": {
     "@hono/node-server": "^2.0.4",
     "ajv": "^8.18.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "hono": "4.12.34",
     "ip-address": "^10.3.1",
     "path-to-regexp": "^8.4.2",
-    "qs": "^6.15.2",
+    "qs": "^6.16.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.11",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "qs": "6.16.0"
   },
   "workspaces": [
     "mcp",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docpull",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Pull public web sources into Claude Code. Indexes static and server-rendered sites as local Markdown with conditional-GET caching, then exposes them as MCP tools. Local, browser-free, no API keys.",
   "author": {
     "name": "Raintree Technology",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "docpull",
   "name": "docpull",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Pull public web sources into Codex as local, searchable Markdown through docpull's MCP server.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,7 +21,7 @@ The plugin wraps the `docpull` CLI. Install the MCP extra first:
 
 ```bash
 pip install 'docpull[mcp]'          # or: pipx install 'docpull[mcp]'
-docpull --version                   # should print 6.5.0 or newer
+docpull --version                   # should print 6.5.1 or newer
 docpull mcp --help
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "6.5.0"
+version = "6.5.1"
 dynamic = []
 description = "Declare, sync, diff, and lock context dependencies for AI agents"
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -110,7 +110,7 @@ tokens = [
 ]
 mcp = [
     "cryptography>=50.0.0",
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",
@@ -156,7 +156,7 @@ all = [
     "trafilatura>=1.12.0",
     "tiktoken>=0.7.0",
     "cryptography>=50.0.0",
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",
     "python-multipart>=0.0.27",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raintree-technology/docpull-sdk",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "TypeScript SDK for reading docpull context packs and running the docpull CLI",
   "license": "MIT",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/raintree-technology/docpull",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "docpull",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from .surface import PUBLIC_SDK_EXPORTS
 
-__version__ = "6.5.0"
+__version__ = "6.5.1"
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     **{

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import tomllib
 import yaml
 
 from docpull.mcp.sources import default_docs_dir
@@ -46,6 +47,15 @@ def project_version() -> str:
             if match:
                 return match.group(1)
     raise AssertionError("Could not find [project].version in pyproject.toml")
+
+
+def test_mcp_extra_excludes_incompatible_major_versions() -> None:
+    project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    mcp_requirements = project["optional-dependencies"]["mcp"]
+    all_requirements = project["optional-dependencies"]["all"]
+
+    assert "mcp>=1.28.1,<2" in mcp_requirements
+    assert "mcp>=1.28.1,<2" in all_requirements
 
 
 def test_github_actions_are_pinned_to_full_commit_shas() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1305,7 +1305,7 @@ wheels = [
 
 [[package]]
 name = "docpull"
-version = "6.5.0"
+version = "6.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1433,8 +1433,8 @@ requires-dist = [
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'markitdown'", specifier = ">=0.1.0" },
     { name = "markitdown", extras = ["docx", "pdf"], marker = "extra == 'parse'", specifier = ">=0.1.0" },
-    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1" },
+    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.28.1,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1,<2" },
     { name = "msgpack", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- constrain the optional MCP runtime to the compatible 1.x series
- add a regression check for both MCP dependency extras
- synchronize Python, TypeScript SDK, plugin, registry, and lockfile versions

## Verification

- `bun run validate:full`
- plugin-creator validator
- skill-creator validator