### PR TITLE
fix(plugin): load the focused activation prompt

### DIFF
--- a/bench/uv.lock
+++ b/bench/uv.lock
@@ -848,7 +848,7 @@ wheels = [
 
 [[package]]
 name = "docpull"
-version = "6.5.2"
+version = "6.5.3"
 source = { editable = "../" }
 dependencies = [
     { name = "aiohttp" },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.3] - 2026-09-04
+
+### Fixed
+- Shorten the Codex activation prompt to the host's 128-character limit so the
+  focused research trigger is loaded instead of ignored.
+
 ## [6.5.2] - 2026-09-04
 
 ### Fixed

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docpull",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "Pull public web sources into Claude Code. Indexes static and server-rendered sites as local Markdown with conditional-GET caching, then exposes them as MCP tools. Local, browser-free, no API keys.",
   "author": {
     "name": "Raintree Technology",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "docpull",
   "name": "docpull",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "Pull public web sources into Codex as local, searchable Markdown through docpull's MCP server.",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
@@ -44,6 +44,6 @@
     "brandColor": "#0F6B5D",
     "composerIcon": "./assets/logo.svg",
     "logo": "./assets/logo.svg",
-    "defaultPrompt": "Use docpull when I ask about a specific library, framework, SDK, API, website, or public source URL. Prefer cached sources first, fetch only the requested source, and cite source paths when answering."
+    "defaultPrompt": "Use DocPull for a named library, framework, SDK, API, website, or public URL. Prefer cached sources and cite source paths."
   }
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,8 +20,8 @@ for the boundary between the plugin's MCP tools and the broader CLI/SDK.
 The plugin wraps the `docpull` CLI. Install the MCP extra first:
 
 ```bash
-pipx install 'docpull[mcp]==6.5.2'
-docpull --version                   # should print 6.5.2 or newer
+pipx install 'docpull[mcp]==6.5.3'
+docpull --version                   # should print 6.5.3 or newer
 docpull mcp --help
 ```
 

--- a/plugin/scripts/launch-docpull-mcp.mjs
+++ b/plugin/scripts/launch-docpull-mcp.mjs
@@ -9,7 +9,7 @@ const child = spawn("docpull", ["mcp", ...process.argv.slice(2)], {
 child.on("error", (error) => {
   if (error.code === "ENOENT") {
     console.error(
-      "DocPull is not installed. Run: pipx install 'docpull[mcp]==6.5.2'",
+      "DocPull is not installed. Run: pipx install 'docpull[mcp]==6.5.3'",
     );
     process.exitCode = 127;
     return;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docpull"
-version = "6.5.2"
+version = "6.5.3"
 dynamic = []
 description = "Declare, sync, diff, and lock context dependencies for AI agents"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raintree-technology/docpull-sdk",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "TypeScript SDK for reading docpull context packs and running the docpull CLI",
   "license": "MIT",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/raintree-technology/docpull",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "docpull",
-      "version": "6.5.2",
+      "version": "6.5.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/docpull/__init__.py
+++ b/src/docpull/__init__.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from .surface import PUBLIC_SDK_EXPORTS
 
-__version__ = "6.5.2"
+__version__ = "6.5.3"
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     **{

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -323,7 +323,15 @@ def test_plugin_launcher_reports_actionable_setup_when_docpull_is_missing() -> N
     )
 
     assert proc.returncode == 127
-    assert "pipx install 'docpull[mcp]==6.5.2'" in proc.stderr
+    assert "pipx install 'docpull[mcp]==6.5.3'" in proc.stderr
+
+
+def test_codex_plugin_default_prompt_fits_host_limit() -> None:
+    manifest = json.loads(
+        (REPO_ROOT / "plugin" / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+
+    assert len(manifest["interface"]["defaultPrompt"]) <= 128
 
 
 def test_mcp_registry_manifest_versions_match_project_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1305,7 +1305,7 @@ wheels = [
 
 [[package]]
 name = "docpull"
-version = "6.5.2"
+version = "6.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- shorten the DocPull Codex activation prompt from 200 to 122 characters
- preserve the focused named-source trigger and cached-source/citation guidance
- add a regression test for Codex's 128-character host limit
- release the corrective package version as 6.5.3

## Validation

- bun run validate:full (1,212 passed, 18 optional skips)
- plugin-creator validation
- focused activation-prompt and launcher regression tests