### PR TITLE
fix(plugin): print exact DocPull setup command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Print only the exact pinned `pipx install` command when the plugin launcher
+  cannot execute DocPull.
+
 ## [6.5.5] - 2026-09-04
 
 ### Fixed

--- a/plugin/scripts/launch-docpull-mcp.mjs
+++ b/plugin/scripts/launch-docpull-mcp.mjs
@@ -8,9 +8,7 @@ const child = spawn("docpull", ["mcp", ...process.argv.slice(2)], {
 
 child.on("error", (error) => {
   if (error.code === "ENOENT" || error.code === "EACCES") {
-    console.error(
-      "DocPull is not installed or is not executable. Run: pipx install 'docpull[mcp]==6.5.5'",
-    );
+    console.error("pipx install 'docpull[mcp]==6.5.5'");
     process.exitCode = 127;
     return;
   }

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -332,7 +332,7 @@ def test_plugin_launcher_reports_actionable_setup_when_docpull_is_missing(
     )
 
     assert proc.returncode == 127
-    assert "pipx install 'docpull[mcp]==6.5.5'" in proc.stderr
+    assert proc.stderr == "pipx install 'docpull[mcp]==6.5.5'\n"
 
     (tmp_path / "docpull").mkdir()
     proc = subprocess.run(  # nosec B603
@@ -345,7 +345,7 @@ def test_plugin_launcher_reports_actionable_setup_when_docpull_is_missing(
     )
 
     assert proc.returncode == 127
-    assert "pipx install 'docpull[mcp]==6.5.5'" in proc.stderr
+    assert proc.stderr == "pipx install 'docpull[mcp]==6.5.5'\n"
 
 
 def test_codex_plugin_default_prompt_fits_host_limit() -> None:


### PR DESCRIPTION
Summary:

- Print only the pinned DocPull installation command when the launcher cannot execute DocPull.
- Require the exact setup message in launcher policy tests.
- Record the unreleased correction in the changelog.

Validation:

- Full validation passed.
- 1,212 Python tests passed and 18 skipped.
- 15 MCP tests passed.
- 14 JavaScript SDK tests passed.